### PR TITLE
feat: add req_id to pallet interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,34 @@ It's under a very early stage. if you are interested in this project, Issues, Di
 
 * [2022-Q3 plan](https://github.com/db3-teams/db3/issues/55)
 
+## Compile
+
+- Upgrade cargo
+
+```bash
+rustup default nightly
+rustup update 
+```
+
+- Check cargo version >= `cargo 1.66.0-nightly` 
+
+
+```bash
+cargo --version
+```
+
+- Compile
+
+```bash
+cargo build --release
+```
+
+- Run
+
+```bash
+./target/release/db3 --dev
+```
+
 ## License
 Apache License, Version 2.0
    ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)

--- a/frame/db/src/lib.rs
+++ b/frame/db/src/lib.rs
@@ -285,9 +285,7 @@ pub mod pallet {
         }
 
         #[pallet::weight(10000)]
-        pub fn create_ns(origin: OriginFor<T>, 
-            ns: Vec<u8>,
-            req_id: Vec<u8>,) -> DispatchResult {
+        pub fn create_ns(origin: OriginFor<T>, ns: Vec<u8>, req_id: Vec<u8>) -> DispatchResult {
             let owner = ensure_signed(origin)?;
             if !<NsOwners<T>>::contains_key(&owner) {
                 let bset: BoundedBTreeSet<
@@ -295,7 +293,7 @@ pub mod pallet {
                     T::MaxBlockTransactions,
                 > = BoundedBTreeSet::new();
                 <NsOwners<T>>::insert(owner.clone(), bset);
-            } 
+            }
             // add owner
             <NsOwners<T>>::mutate(&owner, |bset| {
                 let ns_name: BoundedVec<_, _> = ns
@@ -303,18 +301,16 @@ pub mod pallet {
                     .try_into()
                     .map_err(|()| Error::<T>::TooManyTransactions)
                     .unwrap();
-                
+
                 if let Some(b) = bset {
-                    if let Ok(_) = b.try_insert(ns_name) {
-                    }
+                    if let Ok(_) = b.try_insert(ns_name) {}
                 }
             });
-            Self::deposit_event(
-                Event::GeneralResultEvent{
-                    status : 0,
-                    msg : "ok".as_bytes().to_vec(),
-                    req_id: req_id
-                });
+            Self::deposit_event(Event::GeneralResultEvent {
+                status: 0,
+                msg: "ok".as_bytes().to_vec(),
+                req_id: req_id,
+            });
             Ok(())
         }
 
@@ -363,15 +359,13 @@ pub mod pallet {
                     .unwrap();
                 if let Some(b) = bmap {
                     // TODO check delegate_type
-                    if let Ok(_) = b.try_insert((ns_name, owner.clone()), delegate_type) {
-                    }
+                    if let Ok(_) = b.try_insert((ns_name, owner.clone()), delegate_type) {}
                 }
             });
-            Self::deposit_event(
-                Event::GeneralResultEvent{
-                    status : 0,
-                    msg : "ok".as_bytes().to_vec(),
-                    req_id: req_id
+            Self::deposit_event(Event::GeneralResultEvent {
+                status: 0,
+                msg: "ok".as_bytes().to_vec(),
+                req_id: req_id,
             });
             Ok(())
         }
@@ -397,28 +391,28 @@ pub mod pallet {
                             b.remove(&(ns_name, owner));
                         }
                     });
-                    Self::deposit_event(
-                        Event::GeneralResultEvent{
-                            status : 0,
-                            msg : "ok".as_bytes().to_vec(),
-                            req_id: req_id
-                        });
+                    Self::deposit_event(Event::GeneralResultEvent {
+                        status: 0,
+                        msg: "ok".as_bytes().to_vec(),
+                        req_id: req_id,
+                    });
                 } else {
-                    Self::deposit_event(
-                        Event::GeneralResultEvent{
-                        status : 0,
-                        msg : "fail to delete delegate. Delegate not exist".as_bytes().to_vec(),
-                        req_id: req_id
-                   }); 
+                    Self::deposit_event(Event::GeneralResultEvent {
+                        status: 0,
+                        msg: "fail to delete delegate. Delegate not exist"
+                            .as_bytes()
+                            .to_vec(),
+                        req_id: req_id,
+                    });
                 }
-                
             } else {
-                Self::deposit_event(
-                    Event::GeneralResultEvent{
-                    status : 0,
-                    msg : "fail to delete delegate. Not the owner of ns".as_bytes().to_vec(),
-                    req_id: req_id
-               });
+                Self::deposit_event(Event::GeneralResultEvent {
+                    status: 0,
+                    msg: "fail to delete delegate. Not the owner of ns"
+                        .as_bytes()
+                        .to_vec(),
+                    req_id: req_id,
+                });
             }
             Ok(())
         }
@@ -429,7 +423,7 @@ pub mod pallet {
             delegate: AccountIdLookupOf<T>,
             ns: Vec<u8>,
             delegate_type: u8,
-            req_id: Vec<u8>
+            req_id: Vec<u8>,
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
             let delegate_id = T::Lookup::lookup(delegate)?;
@@ -450,25 +444,22 @@ pub mod pallet {
                         .unwrap();
                     if let Some(b) = bmap {
                         // TODO check delegate_type
-                        if let Ok(_) = b.try_insert((ns_name, owner.clone()), delegate_type) {
-                        }
+                        if let Ok(_) = b.try_insert((ns_name, owner.clone()), delegate_type) {}
                     }
                 });
-                Self::deposit_event(
-                    Event::GeneralResultEvent{
-                        status : 0,
-                        msg : "ok".as_bytes().to_vec(),
-                        req_id: req_id
-                    }
-                );
+                Self::deposit_event(Event::GeneralResultEvent {
+                    status: 0,
+                    msg: "ok".as_bytes().to_vec(),
+                    req_id: req_id,
+                });
             } else {
-                Self::deposit_event(
-                    Event::GeneralResultEvent{
-                        status : 0,
-                        msg : "fail to add delegate. Not the owner of ns".as_bytes().to_vec(),
-                        req_id: req_id
-                    }
-                );
+                Self::deposit_event(Event::GeneralResultEvent {
+                    status: 0,
+                    msg: "fail to add delegate. Not the owner of ns"
+                        .as_bytes()
+                        .to_vec(),
+                    req_id: req_id,
+                });
             }
             Ok(())
         }
@@ -511,12 +502,11 @@ pub mod pallet {
                     return Ok(());
                 }
             }
-            Self::deposit_event(
-                Event::GeneralResultEvent{
-                    status : 0,
-                    msg : "No NS Permission".as_bytes().to_vec(),
-                    req_id: req_id
-                });
+            Self::deposit_event(Event::GeneralResultEvent {
+                status: 0,
+                msg: "No NS Permission".as_bytes().to_vec(),
+                req_id: req_id,
+            });
             Ok(())
         }
 
@@ -552,12 +542,11 @@ pub mod pallet {
                 Self::deposit_event(Event::SQLQueued(data));
                 Ok(())
             } else {
-                Self::deposit_event(
-                    Event::GeneralResultEvent{
-                        status : 0,
-                        msg : "No NS Permission".as_bytes().to_vec(),
-                        req_id: req_id
-                    });
+                Self::deposit_event(Event::GeneralResultEvent {
+                    status: 0,
+                    msg: "No NS Permission".as_bytes().to_vec(),
+                    req_id: req_id,
+                });
                 Ok(())
             }
         }
@@ -728,15 +717,14 @@ pub mod pallet {
         AddDelegateOK(Vec<u8>),
         DeleteDelegateOk(Vec<u8>),
 
-        /// General result event 
+        /// General result event
         GeneralResultEvent {
             status: u32,
             msg: Vec<u8>,
-            req_id: Vec<u8>
+            req_id: Vec<u8>,
         },
         NoNsPermission,
     }
-
 
     /// Collection of transaction metadata by block number.
     #[pallet::storage]

--- a/frame/db/src/lib.rs
+++ b/frame/db/src/lib.rs
@@ -285,7 +285,9 @@ pub mod pallet {
         }
 
         #[pallet::weight(10000)]
-        pub fn create_ns(origin: OriginFor<T>, ns: Vec<u8>) -> DispatchResult {
+        pub fn create_ns(origin: OriginFor<T>, 
+            ns: Vec<u8>,
+            req_id: Vec<u8>,) -> DispatchResult {
             let owner = ensure_signed(origin)?;
             if !<NsOwners<T>>::contains_key(&owner) {
                 let bset: BoundedBTreeSet<
@@ -293,7 +295,7 @@ pub mod pallet {
                     T::MaxBlockTransactions,
                 > = BoundedBTreeSet::new();
                 <NsOwners<T>>::insert(owner.clone(), bset);
-            }
+            } 
             // add owner
             <NsOwners<T>>::mutate(&owner, |bset| {
                 let ns_name: BoundedVec<_, _> = ns
@@ -301,10 +303,18 @@ pub mod pallet {
                     .try_into()
                     .map_err(|()| Error::<T>::TooManyTransactions)
                     .unwrap();
+                
                 if let Some(b) = bset {
-                    if let Ok(_) = b.try_insert(ns_name) {}
+                    if let Ok(_) = b.try_insert(ns_name) {
+                    }
                 }
             });
+            Self::deposit_event(
+                Event::GeneralResultEvent{
+                    status : 0,
+                    msg : "ok".as_bytes().to_vec(),
+                    req_id: req_id
+                });
             Ok(())
         }
 
@@ -314,6 +324,7 @@ pub mod pallet {
             delegate: AccountIdLookupOf<T>,
             ns: Vec<u8>,
             delegate_type: u8,
+            req_id: Vec<u8>,
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
             let dest = T::Lookup::lookup(delegate)?;
@@ -353,9 +364,14 @@ pub mod pallet {
                 if let Some(b) = bmap {
                     // TODO check delegate_type
                     if let Ok(_) = b.try_insert((ns_name, owner.clone()), delegate_type) {
-                        Self::deposit_event(Event::AddDelegateOK(ns));
                     }
                 }
+            });
+            Self::deposit_event(
+                Event::GeneralResultEvent{
+                    status : 0,
+                    msg : "ok".as_bytes().to_vec(),
+                    req_id: req_id
             });
             Ok(())
         }
@@ -365,6 +381,7 @@ pub mod pallet {
             origin: OriginFor<T>,
             delegate: AccountIdLookupOf<T>,
             ns: Vec<u8>,
+            req_id: Vec<u8>,
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
             let delegate_id = T::Lookup::lookup(delegate)?;
@@ -378,10 +395,30 @@ pub mod pallet {
                             .unwrap();
                         if let Some(b) = bmap {
                             b.remove(&(ns_name, owner));
-                            Self::deposit_event(Event::DeleteDelegateOk(ns));
                         }
                     });
+                    Self::deposit_event(
+                        Event::GeneralResultEvent{
+                            status : 0,
+                            msg : "ok".as_bytes().to_vec(),
+                            req_id: req_id
+                        });
+                } else {
+                    Self::deposit_event(
+                        Event::GeneralResultEvent{
+                        status : 0,
+                        msg : "fail to delete delegate. Delegate not exist".as_bytes().to_vec(),
+                        req_id: req_id
+                   }); 
                 }
+                
+            } else {
+                Self::deposit_event(
+                    Event::GeneralResultEvent{
+                    status : 0,
+                    msg : "fail to delete delegate. Not the owner of ns".as_bytes().to_vec(),
+                    req_id: req_id
+               });
             }
             Ok(())
         }
@@ -392,6 +429,7 @@ pub mod pallet {
             delegate: AccountIdLookupOf<T>,
             ns: Vec<u8>,
             delegate_type: u8,
+            req_id: Vec<u8>
         ) -> DispatchResult {
             let owner = ensure_signed(origin)?;
             let delegate_id = T::Lookup::lookup(delegate)?;
@@ -413,10 +451,24 @@ pub mod pallet {
                     if let Some(b) = bmap {
                         // TODO check delegate_type
                         if let Ok(_) = b.try_insert((ns_name, owner.clone()), delegate_type) {
-                            Self::deposit_event(Event::AddDelegateOK(ns));
                         }
                     }
                 });
+                Self::deposit_event(
+                    Event::GeneralResultEvent{
+                        status : 0,
+                        msg : "ok".as_bytes().to_vec(),
+                        req_id: req_id
+                    }
+                );
+            } else {
+                Self::deposit_event(
+                    Event::GeneralResultEvent{
+                        status : 0,
+                        msg : "fail to add delegate. Not the owner of ns".as_bytes().to_vec(),
+                        req_id: req_id
+                    }
+                );
             }
             Ok(())
         }
@@ -459,7 +511,12 @@ pub mod pallet {
                     return Ok(());
                 }
             }
-            Self::deposit_event(Event::NoNsPermission);
+            Self::deposit_event(
+                Event::GeneralResultEvent{
+                    status : 0,
+                    msg : "No NS Permission".as_bytes().to_vec(),
+                    req_id: req_id
+                });
             Ok(())
         }
 
@@ -495,7 +552,12 @@ pub mod pallet {
                 Self::deposit_event(Event::SQLQueued(data));
                 Ok(())
             } else {
-                Self::deposit_event(Event::NoNsPermission);
+                Self::deposit_event(
+                    Event::GeneralResultEvent{
+                        status : 0,
+                        msg : "No NS Permission".as_bytes().to_vec(),
+                        req_id: req_id
+                    });
                 Ok(())
             }
         }
@@ -665,8 +727,16 @@ pub mod pallet {
         SQLResult(Vec<u8>),
         AddDelegateOK(Vec<u8>),
         DeleteDelegateOk(Vec<u8>),
+
+        /// General result event 
+        GeneralResultEvent {
+            status: u32,
+            msg: Vec<u8>,
+            req_id: Vec<u8>
+        },
         NoNsPermission,
     }
+
 
     /// Collection of transaction metadata by block number.
     #[pallet::storage]


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
## What
ISSUE: https://github.com/dbpunk-labs/db3/issues/76
Support req_id in the newly added pallet calls API

create_ns
create_ns_and_add_delegate
add_delegate
delete_delegate

## Why
let the frontend to get right response by adding reqid to pallet

## Testing

### CreateNS

- (Alice) Request:
sqldb#CreateNs
ns: db_test
reqId: 1234

- Response:
sqldb:GeneralResultEvent
[“0”,“ok”,“1234”] 



### runSqlByOwner
- (Alice) Request:
sqldb#runSqlByOwner
ns: db_test
data:
create table location
(
    id INT NOT NULL PRIMARY KEY,
    coordinates VARCHAR(50)
);
reqId: 1235

- Response:
[“{\“status\“:0, \“msg\“:\“ok\“,\“req_id\“:\“1235\“}”]


### runSqlByOwner

- (Alice) Request:
sqldb#runSqlByOwner
ns: db_test
data:
insert into location values
(1, '37.772,-122.214'),
(2, '21.291,-157.821'),
(3, '-18.142,178.431'),
(4, '-27.467,153.027');
reqId: 1236

- Response:
[“{\“status\“:0, \“msg\“:\“ok\“,\“req_id\“:\“1236\“}”] 


### runSqlByOwner

- (Alice) Request:
sqldb#runSqlByOwner
ns: db_test
data:
select * from location;
reqId: 1237

- Response:
sqldb:SQLResult
[“{\“status\“:0, \“msg\“:\“ok\“, \“schema\“:{\“fields\“:[{\“name\“:\“id\“,\“nullable\“:true,\“type\“:{\“name\“:\“int\“,\“bitWidth\“:32,\“isSigned\“:true},\“children\“:[]},{\“name\“:\“coordinates\“,\“nullable\“:true,\“type\“:{\“name\“:\“utf8\“},\“children\“:[]}],\“metadata\“:{}}, \“data\“:[{\“id\“:1,\“coordinates\“:\“37.772,-122.214\“},{\“id\“:2,\“coordinates\“:\“21.291,-157.821\“},{\“id\“:3,\“coordinates\“:\“-18.142,178.431\“},{\“id\“:4,\“coordinates\“:\“-27.467,153.027\“}], \“req_id\“:\“1237\“}”] 


### runSqlByOwner without NS permission

- (Bob) Request:
sqldb#runSqlByOwner
ns: db_test
data
select * from location;
reqId: 1238

- Response:
sqldb:GeneralResultEvent
[“0”,“No NS Permission”,“1238”] (edited) 


### addDelegate 

- (Alicia) Request
sqldb#addDelegate
dalegate: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
ns: db_test
delegateType: 1
reqId: 1239

- Response:
sqldb:GeneralResultEvent
[“0”,“ok”,“1239”]

### runSqlByDelegate

- (Bob) Request:
sqldb#runSqlByDelegate
ns: db_test
owner: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
data
select * from location;
reqId: 1238

- Response:
sqldb:SQLResult
[“{\“status\“:0, \“msg\“:\“ok\“, \“schema\“:{\“fields\“:[{\“name\“:\“id\“,\“nullable\“:true,\“type\“:{\“name\“:\“int\“,\“bitWidth\“:32,\“isSigned\“:true},\“children\“:[]},{\“name\“:\“coordinates\“,\“nullable\“:true,\“type\“:{\“name\“:\“utf8\“},\“children\“:[]}],\“metadata\“:{}}, \“data\“:[{\“id\“:1,\“coordinates\“:\“37.772,-122.214\“},{\“id\“:2,\“coordinates\“:\“21.291,-157.821\“},{\“id\“:3,\“coordinates\“:\“-18.142,178.431\“},{\“id\“:4,\“coordinates\“:\“-27.467,153.027\“}], \“req_id\“:\“1240\“}”]


### deleteDelegate 

- (Alice) Request:
sqldb#deleteDelegate
dalegate: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
ns: db_test
reqId: 1241

- Response:
sqldb:GeneralResultEvent
[“0”,“ok”,“1241”]


### deleteDelegate -  Not the owner of ns

- (Alice) Request:
sqldb#deleteDelegate
dalegate: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
ns: db_test_not_exist
reqId: 1243

- Response: 
sqldb:GeneralResultEvent
[“0”,“fail to delete delegate. Not the owner of ns”,“1243”]


### deleteDelegate - delegate not exist

- (Alice) Request:
sqldb#deleteDelegate
dalegate: 5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy
ns: db_test
reqId: 1261

- Response: 
sqldb:GeneralResultEvent
[“0”,“fail to delete delegate. Delegate not exist”,“1261”]