### PR TITLE
fix: update status code to non-zero when fail

### DIFF
--- a/frame/db/src/lib.rs
+++ b/frame/db/src/lib.rs
@@ -398,7 +398,7 @@ pub mod pallet {
                     });
                 } else {
                     Self::deposit_event(Event::GeneralResultEvent {
-                        status: 0,
+                        status: 1,
                         msg: "fail to delete delegate. Delegate not exist"
                             .as_bytes()
                             .to_vec(),
@@ -407,7 +407,7 @@ pub mod pallet {
                 }
             } else {
                 Self::deposit_event(Event::GeneralResultEvent {
-                    status: 0,
+                    status: 1,
                     msg: "fail to delete delegate. Not the owner of ns"
                         .as_bytes()
                         .to_vec(),
@@ -454,7 +454,7 @@ pub mod pallet {
                 });
             } else {
                 Self::deposit_event(Event::GeneralResultEvent {
-                    status: 0,
+                    status: 1,
                     msg: "fail to add delegate. Not the owner of ns"
                         .as_bytes()
                         .to_vec(),
@@ -503,7 +503,7 @@ pub mod pallet {
                 }
             }
             Self::deposit_event(Event::GeneralResultEvent {
-                status: 0,
+                status: 1,
                 msg: "No NS Permission".as_bytes().to_vec(),
                 req_id: req_id,
             });
@@ -543,7 +543,7 @@ pub mod pallet {
                 Ok(())
             } else {
                 Self::deposit_event(Event::GeneralResultEvent {
-                    status: 0,
+                    status: 1,
                     msg: "No NS Permission".as_bytes().to_vec(),
                     req_id: req_id,
                 });


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
CreateNS
(Alice) Request:
sqldb#CreateNs
ns: db_test
reqId: 1234

Response:
sqldb:GeneralResultEvent
[“0”,“ok”,“1234”]

runSqlByOwner
(Alice) Request:
sqldb#runSqlByOwner
ns: db_test
data:
create table location
(
id INT NOT NULL PRIMARY KEY,
coordinates VARCHAR(50)
);
reqId: 1235

Response:
[“{\“status\“:0, \“msg\“:\“ok\“,\“req_id\“:\“1235\“}”]

runSqlByOwner
(Alice) Request:
sqldb#runSqlByOwner
ns: db_test
data:
insert into location values
(1, '37.772,-122.214'),
(2, '21.291,-157.821'),
(3, '-18.142,178.431'),
(4, '-27.467,153.027');
reqId: 1236

Response:
[“{\“status\“:0, \“msg\“:\“ok\“,\“req_id\“:\“1236\“}”]

runSqlByOwner
(Alice) Request:
sqldb#runSqlByOwner
ns: db_test
data:
select * from location;
reqId: 1237

Response:
sqldb:SQLResult
[“{\“status\“:0, \“msg\“:\“ok\“, \“schema\“:{\“fields\“:[{\“name\“:\“id\“,\“nullable\“:true,\“type\“:{\“name\“:\“int\“,\“bitWidth\“:32,\“isSigned\“:true},\“children\“:[]},{\“name\“:\“coordinates\“,\“nullable\“:true,\“type\“:{\“name\“:\“utf8\“},\“children\“:[]}],\“metadata\“:{}}, \“data\“:[{\“id\“:1,\“coordinates\“:\“37.772,-122.214\“},{\“id\“:2,\“coordinates\“:\“21.291,-157.821\“},{\“id\“:3,\“coordinates\“:\“-18.142,178.431\“},{\“id\“:4,\“coordinates\“:\“-27.467,153.027\“}], \“req_id\“:\“1237\“}”]

runSqlByOwner without NS permission
(Bob) Request:
sqldb#runSqlByOwner
ns: db_test
data
select * from location;
reqId: 1238

Response:
sqldb:GeneralResultEvent
[“1”,“No NS Permission”,“1238”] (edited)

addDelegate
(Alicia) Request
sqldb#addDelegate
dalegate: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
ns: db_test
delegateType: 1
reqId: 1239

Response:
sqldb:GeneralResultEvent
[“0”,“ok”,“1239”]

runSqlByDelegate
(Bob) Request:
sqldb#runSqlByDelegate
ns: db_test
owner: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
data
select * from location;
reqId: 1238

Response:
sqldb:SQLResult
[“{\“status\“:0, \“msg\“:\“ok\“, \“schema\“:{\“fields\“:[{\“name\“:\“id\“,\“nullable\“:true,\“type\“:{\“name\“:\“int\“,\“bitWidth\“:32,\“isSigned\“:true},\“children\“:[]},{\“name\“:\“coordinates\“,\“nullable\“:true,\“type\“:{\“name\“:\“utf8\“},\“children\“:[]}],\“metadata\“:{}}, \“data\“:[{\“id\“:1,\“coordinates\“:\“37.772,-122.214\“},{\“id\“:2,\“coordinates\“:\“21.291,-157.821\“},{\“id\“:3,\“coordinates\“:\“-18.142,178.431\“},{\“id\“:4,\“coordinates\“:\“-27.467,153.027\“}], \“req_id\“:\“1240\“}”]

deleteDelegate
(Alice) Request:
sqldb#deleteDelegate
dalegate: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
ns: db_test
reqId: 1241

Response:
sqldb:GeneralResultEvent
[“0”,“ok”,“1241”]

deleteDelegate - Not the owner of ns
(Alice) Request:
sqldb#deleteDelegate
dalegate: 5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty
ns: db_test_not_exist
reqId: 1243

Response:
sqldb:GeneralResultEvent
[“1”,“fail to delete delegate. Not the owner of ns”,“1243”]

deleteDelegate - delegate not exist
(Alice) Request:
sqldb#deleteDelegate
dalegate: 5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy
ns: db_test
reqId: 1261

Response:
sqldb:GeneralResultEvent
[“1”,“fail to delete delegate. Delegate not exist”,“1261”]