### PR TITLE
support criterion

### DIFF
--- a/src/node/Cargo.toml
+++ b/src/node/Cargo.toml
@@ -45,7 +45,7 @@ prost = "0.11"
 prost-types = "0.11"
 tokio = { version = "1.17.0", features = ["full"] }
 clap = { version = "4.0.20", features = ["derive"] }
-subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
+subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview", "base64"] }
 http = "0.2"
 shadow-rs = "0.19.0"
 tower-http = { version = "0.3", features = ["cors"] }

--- a/src/node/src/storage_node_impl.rs
+++ b/src/node/src/storage_node_impl.rs
@@ -342,6 +342,7 @@ impl StorageNode for StorageNodeImpl {
         &self,
         request: Request<GetKeyRequest>,
     ) -> std::result::Result<Response<GetKeyResponse>, Status> {
+        println!("enter get_key >>");
         if let Some(batch_get_key) = request.into_inner().batch_get {
             match self.context.node_store.lock() {
                 Ok(mut node_store) => {
@@ -379,6 +380,7 @@ impl StorageNode for StorageNodeImpl {
                         .get_session_mut(&batch_get_key.session_token)
                         .unwrap()
                         .increase_query(1);
+                    println!("exit get_key >>");
                     Ok(Response::new(GetKeyResponse {
                         batch_get_values: Some(values.to_owned()),
                     }))
@@ -386,6 +388,7 @@ impl StorageNode for StorageNodeImpl {
                 Err(e) => Err(Status::internal(format!("Fail to get key {}", e))),
             }
         } else {
+            println!("Err get key");
             Err(Status::invalid_argument(
                 "batch key is empty or none".to_string(),
             ))

--- a/src/sdk/Cargo.toml
+++ b/src/sdk/Cargo.toml
@@ -21,12 +21,8 @@ tonic-web = "0.5.0"
 prost = "0.11"
 prost-types = "0.11"
 ethereum-types = { version = "0.14.0", default-features = false }
-subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview"] }
+subtle-encoding = { version = "0.5", default-features = false, features = ["bech32-preview", "base64"] }
 chrono = "0.4.22"
-[dev-dependencies]
-rand = "0.8.5"
-db3-base={path="../base", version="0.1.0"}
-db3-cmd={path="../cmd", version="0.1.0"}
 [dependencies.uuid]
 version = "1.2.2"
 features = [
@@ -34,3 +30,13 @@ features = [
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
     "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
 ]
+[dev-dependencies]
+rand = "0.8.5"
+db3-base={path="../base", version="0.1.0"}
+db3-cmd={path="../cmd", version="0.1.0"}
+criterion = { version = "0.4.0", default-features = false,features = ["async_futures"]}
+futures-lite = "1.12"
+
+[[bench]]
+name = "rust_sdk_benchmark"
+harness = false

--- a/src/sdk/benches/my_benchmark.rs
+++ b/src/sdk/benches/my_benchmark.rs
@@ -1,0 +1,26 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+
+#[inline]
+fn fibonacci(n: u64) -> u64 {
+    let mut a = 0;
+    let mut b = 1;
+
+    match n {
+        0 => b,
+        _ => {
+            for _ in 0..n {
+                let c = a + b;
+                a = b;
+                b = c;
+            }
+            b
+        }
+    }
+}
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("fib_20", |b| b.iter(|| fibonacci(black_box(20))));
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/sdk/benches/rust_sdk_benchmark.rs
+++ b/src/sdk/benches/rust_sdk_benchmark.rs
@@ -1,0 +1,136 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use bytes::BytesMut;
+use chrono::Utc;
+use db3_base::{get_a_random_nonce, get_a_static_keypair, get_address_from_pk};
+use db3_proto::db3_base_proto::{ChainId, ChainRole};
+use db3_proto::db3_mutation_proto::KvPair;
+use db3_proto::db3_mutation_proto::{Mutation, MutationAction};
+use db3_proto::db3_node_proto::storage_node_client::StorageNodeClient;
+use std::sync::Arc;
+use std::time;
+use tonic::transport::Endpoint;
+use uuid::Uuid;
+use db3_crypto::signer::Db3Signer;
+use db3_sdk::mutation_sdk::MutationSDK;
+use db3_sdk::store_sdk::StoreSDK;
+use db3_session::session_manager::DEFAULT_SESSION_QUERY_LIMIT;
+use tonic::Code;
+// This is a struct that tells Criterion.rs to use the "futures" crate's current-thread executor
+use criterion::async_executor::FuturesExecutor;
+use std::process::exit;
+use std::cell::RefCell;
+use std::rc;
+// This is a struct that tells Criterion.rs to use the "futures" crate's current-thread executor
+use std::rc::Rc;
+use tokio::runtime::Runtime;
+use tokio::time::{sleep, Duration};
+use futures_lite::future::block_on;
+
+// Here we have an async function to benchmark
+async fn run_batch_get() {
+    println!("start run batch get");
+    let nonce = get_a_random_nonce();
+    let ep = "http://127.0.0.1:26659";
+    let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
+    let channel = rpc_endpoint.connect_lazy();
+    let client = Arc::new(StorageNodeClient::new(channel));
+    let key_vec = format!("kkkkk_tt{}", 10).as_bytes().to_vec();
+    let value_vec = format!("vkalue_tt{}", 10).as_bytes().to_vec();
+    let ns_vec = "my_twitter".as_bytes().to_vec();
+
+    let kp = get_a_static_keypair();
+    let addr = get_address_from_pk(&kp.public);
+    let signer = Db3Signer::new(kp);
+    let mut sdk = StoreSDK::new(client, signer);
+    let res = sdk.open_session().await;
+    assert!(res.is_ok());
+    let session_info = res.unwrap();
+    println!("open session with token {}", &session_info.session_token);
+    for i in 0..DEFAULT_SESSION_QUERY_LIMIT {
+        // if i % 10 == 0 {
+        // }
+        println!("process {} queries", i);
+        if let Ok(Some(values)) = sdk
+            .batch_get(&ns_vec, vec![key_vec.clone()], &session_info.session_token)
+            .await
+        {
+            assert_eq!(values.values.len(), 1);
+        } else {
+            println!("fail to query keys");
+        }
+        println!("done process {} queries", i);
+    }
+    let res = sdk.close_session(&session_info.session_token).await;
+    println!("close session ");
+}
+
+async fn foo() {
+    // ...
+}
+async fn init_kv_store() {
+    let nonce = get_a_random_nonce();
+
+    let ep = "http://127.0.0.1:26659";
+    let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
+    let channel = rpc_endpoint.connect_lazy();
+    let client = Arc::new(StorageNodeClient::new(channel));
+    let mclient = client.clone();
+    let sclient = client.clone();
+    let key_vec = format!("kkkkk_tt{}", 10).as_bytes().to_vec();
+    let value_vec = format!("vkalue_tt{}", 10).as_bytes().to_vec();
+    let ns_vec = "my_twitter".as_bytes().to_vec();
+    let kp = get_a_static_keypair();
+    let signer = Db3Signer::new(kp);
+    let msdk = MutationSDK::new(mclient, signer);
+    let kv = KvPair {
+        key: key_vec.clone(),
+        value: value_vec.clone(),
+        action: MutationAction::InsertKv.into(),
+    };
+    let mutation = Mutation {
+        ns: ns_vec.clone(),
+        kv_pairs: vec![kv],
+        nonce,
+        chain_id: ChainId::MainNet.into(),
+        chain_role: ChainRole::StorageShardChain.into(),
+        gas_price: None,
+        gas: 10,
+    };
+    println!("start submit mutation");
+    let result = msdk.submit_mutation(&mutation).await;
+    assert!(result.is_ok(), "{}", result.err().unwrap());
+    let two_sec = Duration::from_millis(2000);
+    println!("done submit mutation");
+    sleep(two_sec).await;
+    println!("wake up after submit");
+}
+fn criterion_benchmark_compile_fail(c: &mut Criterion) {
+    println!("criterion_benchmark....");
+
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        init_kv_store().await;
+    });
+    c.bench_function("batch get bench", move |b| {
+            b.to_async(FuturesExecutor)
+                // ., |_| async move { run_batch_get().await;});
+                .iter(|| run_batch_get())
+    });
+}
+fn criterion_benchmark(c: &mut Criterion) {
+    println!("criterion_benchmark....");
+
+    let rt = Runtime::new().unwrap();
+    rt.block_on(async {
+        init_kv_store().await;
+    });
+    c.bench_function("batch get bench", move |b| {
+        rt.block_on(async {
+            b.to_async(FuturesExecutor).iter(|| async move { run_batch_get().await; });
+        });
+    });
+}
+// Example: https://github.com/bheisler/criterion.rs/tree/master/benches/benchmarks
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

```
cargo bench --package db3-sdk
```


#### Issue
```
Benchmarking iter: Warming up for 3.0000 sstart run batch get
thread 'main' panicked at 'there is no reactor running, must be called from the context of a Tokio 1.x runtime', /Users/chenjing/.cargo/registry/src/github.com-1ecc6299db9ec823/tonic-0.8.3/src/transport/service/executor.rs:15:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
