### PR TITLE
Feat/query with lt gt condition

### DIFF
--- a/src/base/src/bson_util.rs
+++ b/src/base/src/bson_util.rs
@@ -177,7 +177,11 @@ pub fn filter_from_json_value(json_str: &str) -> std::result::Result<Option<Filt
         })?;
         let op = match op_str {
             "==" => Operator::Equal,
-            ">" | "<" | ">=" | "<=" | "!=" => {
+            ">" => Operator::GreaterThan,
+            "<" => Operator::LessThan,
+            ">=" => Operator::GreaterThanOrEqual,
+            "<=" => Operator::LessThanOrEqual,
+            "!=" => {
                 return Err(DB3Error::InvalidFilterOp(format!(
                     "OP {} un-support currently",
                     op_str
@@ -403,6 +407,35 @@ mod tests {
             .unwrap();
         assert_eq!(
             r#"{"filter_type":{"FieldFilter":{"field":"flag","op":5,"value":{"value_type":{"BooleanValue":true}}}}}"#,
+            serde_json::to_string(&filter).unwrap()
+        );
+
+        let filter = filter_from_json_value(r#"{"field": "flag", "value": true, "op": ">="}"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            r#"{"filter_type":{"FieldFilter":{"field":"flag","op":4,"value":{"value_type":{"BooleanValue":true}}}}}"#,
+            serde_json::to_string(&filter).unwrap()
+        );
+        let filter = filter_from_json_value(r#"{"field": "flag", "value": true, "op": ">"}"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            r#"{"filter_type":{"FieldFilter":{"field":"flag","op":3,"value":{"value_type":{"BooleanValue":true}}}}}"#,
+            serde_json::to_string(&filter).unwrap()
+        );
+        let filter = filter_from_json_value(r#"{"field": "flag", "value": true, "op": "<="}"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            r#"{"filter_type":{"FieldFilter":{"field":"flag","op":2,"value":{"value_type":{"BooleanValue":true}}}}}"#,
+            serde_json::to_string(&filter).unwrap()
+        );
+        let filter = filter_from_json_value(r#"{"field": "flag", "value": true, "op": "<"}"#)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            r#"{"filter_type":{"FieldFilter":{"field":"flag","op":1,"value":{"value_type":{"BooleanValue":true}}}}}"#,
             serde_json::to_string(&filter).unwrap()
         );
 

--- a/src/storage/src/db_store.rs
+++ b/src/storage/src/db_store.rs
@@ -793,7 +793,9 @@ impl DbStore {
         match &range.0 {
             Bound::Included(start) => it.seek(start.as_ref()),
             Bound::Excluded(start) => {
-                it.seek(start.as_ref());
+                // 1. Seeks to the start key, or the first key that lexicographically precedes it.
+                // 2. Advance iterator to the next key to exclude the start key
+                it.seek_for_prev(start.as_ref());
                 if it.valid() {
                     it.next();
                 }

--- a/src/storage/src/db_store.rs
+++ b/src/storage/src/db_store.rs
@@ -30,7 +30,6 @@ use db3_proto::db3_database_proto::{Collection, Database, Document, Index, Struc
 use db3_proto::db3_mutation_proto::{DatabaseAction, DatabaseMutation};
 use db3_types::cost::DbStoreOp;
 use itertools::Itertools;
-use merkdb::proofs::{Node, Op as ProofOp};
 use merkdb::{tree::Tree, BatchEntry, Merk, Op};
 use prost::Message;
 use std::collections::{HashMap, HashSet};
@@ -746,8 +745,7 @@ impl DbStore {
                                             keys.as_slice(),
                                             &DocumentId::one(),
                                         )?;
-                                        (Bound::Included(start_key),
-                                         Bound::Included(end_key))
+                                        (Bound::Included(start_key), Bound::Included(end_key))
                                     }
                                     _ => {
                                         return Err(DB3Error::InvalidFilterType(format!(
@@ -783,11 +781,11 @@ impl DbStore {
     }
 
     /// execute a query to fetch target documents from given database and index range
-    fn execute_query(db: Pin<&Merk>, range: &(Bound<IndexId>, Bound<IndexId>),
-                     limit: Option<i32>) -> Result<Vec<Document>> {
-        // let ops = db
-        //     .execute_query(query)
-        //     .map_err(|e| DB3Error::QueryKvError(format!("{}", e)))?;
+    fn execute_query(
+        db: Pin<&Merk>,
+        range: &(Bound<IndexId>, Bound<IndexId>),
+        limit: Option<i32>,
+    ) -> Result<Vec<Document>> {
         let mut values: Vec<_> = Vec::new();
         let mut count = 0;
 
@@ -799,7 +797,7 @@ impl DbStore {
                 if it.valid() {
                     it.next();
                 }
-            },
+            }
             Bound::Unbounded => it.seek_to_first(),
         };
 
@@ -830,13 +828,11 @@ impl DbStore {
                 }
                 let index_id = IndexId::new(k.to_vec());
                 let document_id = index_id.get_document_id()?;
-                if let Ok(Some(document)) =
-                    Self::get_document(db, &document_id)
-                {
+                if let Ok(Some(document)) = Self::get_document(db, &document_id) {
                     count += 1;
                     values.push(document)
                 } else {
-                    warn!("document not exist with target id {}",document_id);
+                    warn!("document not exist with target id {}", document_id);
                 }
             }
             it.next();

--- a/src/storage/src/db_store.rs
+++ b/src/storage/src/db_store.rs
@@ -720,7 +720,7 @@ impl DbStore {
                                     }
                                 };
 
-                                let keys = match &field_filter.value {
+                                let key = match &field_filter.value {
                                     Some(value) => bson_util::bson_into_comparison_bytes(
                                         &bson_util::bson_value_from_proto_value(value)?,
                                     )?,
@@ -730,30 +730,12 @@ impl DbStore {
                                         ));
                                     }
                                 };
-                                let range = match Operator::from_i32(field_filter.op) {
-                                    Some(Operator::Equal) => {
-                                        let start_key = IndexId::create(
-                                            &collection_id,
-                                            index.id,
-                                            keys.as_slice(),
-                                            &DocumentId::zero(),
-                                        )?;
-
-                                        let end_key = IndexId::create(
-                                            &collection_id,
-                                            index.id,
-                                            keys.as_slice(),
-                                            &DocumentId::one(),
-                                        )?;
-                                        (Bound::Included(start_key), Bound::Included(end_key))
-                                    }
-                                    _ => {
-                                        return Err(DB3Error::InvalidFilterType(format!(
-                                            "Filed Filter Op {:?} un-support",
-                                            &field_filter.op
-                                        )));
-                                    }
-                                };
+                                let range = Self::generate_range_with_single_field_filter(
+                                    &collection_id,
+                                    index,
+                                    &key,
+                                    Operator::from_i32(field_filter.op),
+                                )?;
                                 Self::execute_query(db, &range, limit)
                             }
                             None => {
@@ -777,6 +759,85 @@ impl DbStore {
                 db_id.to_hex()
             ))),
             Err(e) => Err(e),
+        }
+    }
+
+    /// generate range for single field filter
+    /// e.g : field = "name", value = "jack", op = "equal"
+    /// range = [name:jack:00000, name:jack:11111]
+    /// e.g : field = "name", value = "jack", op = "less_than"
+    /// range = (unbounded, name:jack:00000)
+    /// etc.
+    fn generate_range_with_single_field_filter(
+        collection_id: &CollectionId,
+        index: &Index,
+        key: &Vec<u8>,
+        op: Option<Operator>,
+    ) -> Result<(Bound<IndexId>, Bound<IndexId>)> {
+        match op {
+            Some(Operator::Equal) => {
+                let start_key = IndexId::create(
+                    &collection_id,
+                    index.id,
+                    key.as_slice(),
+                    &DocumentId::zero(),
+                )?;
+
+                let end_key =
+                    IndexId::create(&collection_id, index.id, key.as_slice(), &DocumentId::one())?;
+                Ok((Bound::Included(start_key), Bound::Included(end_key)))
+            }
+            Some(Operator::LessThan) => {
+                let start_key =
+                    IndexId::create(&collection_id, index.id, "".as_bytes(), &DocumentId::zero())?;
+                let end_key = IndexId::create(
+                    &collection_id,
+                    index.id,
+                    key.as_slice(),
+                    &DocumentId::zero(),
+                )?;
+                Ok((Bound::Included(start_key), Bound::Excluded(end_key)))
+            }
+            Some(Operator::LessThanOrEqual) => {
+                let start_key =
+                    IndexId::create(&collection_id, index.id, "".as_bytes(), &DocumentId::zero())?;
+                let end_key =
+                    IndexId::create(&collection_id, index.id, key.as_slice(), &DocumentId::one())?;
+                Ok((Bound::Included(start_key), Bound::Included(end_key)))
+            }
+            Some(Operator::GreaterThan) => {
+                let start_key =
+                    IndexId::create(&collection_id, index.id, key.as_slice(), &DocumentId::one())?;
+                let end_key = IndexId::create(
+                    &collection_id,
+                    index.id + 1,
+                    "".as_bytes(),
+                    &DocumentId::zero(),
+                )?;
+                Ok((Bound::Excluded(start_key), Bound::Excluded(end_key)))
+            }
+            Some(Operator::GreaterThanOrEqual) => {
+                let start_key = IndexId::create(
+                    &collection_id,
+                    index.id,
+                    key.as_slice(),
+                    &DocumentId::zero(),
+                )?;
+                let end_key = IndexId::create(
+                    &collection_id,
+                    index.id + 1,
+                    "".as_bytes(),
+                    &DocumentId::zero(),
+                )?;
+                Ok((Bound::Included(start_key), Bound::Excluded(end_key)))
+            }
+            _ => {
+                // TODO: support more not equal operator
+                return Err(DB3Error::InvalidFilterType(format!(
+                    "Filed Filter Op {:?} un-support",
+                    op
+                )));
+            }
         }
     }
 
@@ -811,10 +872,10 @@ impl DbStore {
         it_end.seek_to_last();
         let it_end_key = it_end.key().unwrap();
 
-        let (end_key_ref, end_key_include) = match &range.1 {
-            Bound::Unbounded => (it_end_key, true),
-            Bound::Included(end) => (end.as_ref().as_slice(), true),
-            Bound::Excluded(end) => (end.as_ref().as_slice(), false),
+        let (end_key_ref, end_key_exclude) = match &range.1 {
+            Bound::Unbounded => (it_end_key, false),
+            Bound::Included(end) => (end.as_ref().as_slice(), false),
+            Bound::Excluded(end) => (end.as_ref().as_slice(), true),
         };
 
         while it.valid() {
@@ -825,7 +886,7 @@ impl DbStore {
                 if k > end_key_ref {
                     break;
                 }
-                if end_key_include && k == end_key_ref {
+                if k == end_key_ref && end_key_exclude {
                     break;
                 }
                 let index_id = IndexId::new(k.to_vec());
@@ -1019,6 +1080,7 @@ impl DbStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bson::Bson;
     use db3_base::bson_util;
     use db3_crypto::key_derive;
     use db3_crypto::signature_scheme::SignatureScheme;
@@ -1034,6 +1096,7 @@ mod tests {
     use db3_proto::db3_mutation_proto::DocumentMask;
     use db3_proto::db3_mutation_proto::DocumentMutation;
     use std::boxed::Box;
+    use std::ops::Bound::{Excluded, Included};
     use tempdir::TempDir;
 
     fn gen_address() -> DB3Address {
@@ -1414,6 +1477,113 @@ mod tests {
         assert_eq!("Bill", document.get_str("name").unwrap());
         let document = bson_util::bytes_to_bson_document(docs[1].doc.clone()).unwrap();
         assert_eq!("Bill", document.get_str("name").unwrap());
+
+        // test query with <, <=, >, >= condition
+        // run query: select * from collection where name < "John Doe"
+        let query = StructuredQuery {
+            collection_name: collection_name.to_string(),
+            select: Some(Projection { fields: vec![] }),
+            r#where: Some(Filter {
+                filter_type: Some(FilterType::FieldFilter(FieldFilter {
+                    field: "name".to_string(),
+                    op: Operator::LessThan.into(),
+                    value: Some(Value {
+                        value_type: Some(ValueType::StringValue("John Doe".to_string())),
+                    }),
+                })),
+            }),
+            limit: None,
+        };
+        let docs = DbStore::run_query(db.as_ref(), &db_id, &query).unwrap();
+        assert_eq!(2, docs.len());
+        let document = bson_util::bytes_to_bson_document(docs[0].doc.clone()).unwrap();
+        assert_eq!("Bill", document.get_str("name").unwrap());
+        let document = bson_util::bytes_to_bson_document(docs[1].doc.clone()).unwrap();
+        assert_eq!("Bill", document.get_str("name").unwrap());
+
+        // run query: select * from collection where name <= "John Doe"
+        let query = StructuredQuery {
+            collection_name: collection_name.to_string(),
+            select: Some(Projection { fields: vec![] }),
+            r#where: Some(Filter {
+                filter_type: Some(FilterType::FieldFilter(FieldFilter {
+                    field: "name".to_string(),
+                    op: Operator::LessThanOrEqual.into(),
+                    value: Some(Value {
+                        value_type: Some(ValueType::StringValue("John Doe".to_string())),
+                    }),
+                })),
+            }),
+            limit: None,
+        };
+        let docs = DbStore::run_query(db.as_ref(), &db_id, &query).unwrap();
+        assert_eq!(3, docs.len());
+        let document = bson_util::bytes_to_bson_document(docs[0].doc.clone()).unwrap();
+        assert_eq!("Bill", document.get_str("name").unwrap());
+        let document = bson_util::bytes_to_bson_document(docs[1].doc.clone()).unwrap();
+        assert_eq!("Bill", document.get_str("name").unwrap());
+        let document = bson_util::bytes_to_bson_document(docs[2].doc.clone()).unwrap();
+        assert_eq!("John Doe", document.get_str("name").unwrap());
+
+        // run query: select * from collection where name > "John Doe"
+        let query = StructuredQuery {
+            collection_name: collection_name.to_string(),
+            select: Some(Projection { fields: vec![] }),
+            r#where: Some(Filter {
+                filter_type: Some(FilterType::FieldFilter(FieldFilter {
+                    field: "name".to_string(),
+                    op: Operator::GreaterThan.into(),
+                    value: Some(Value {
+                        value_type: Some(ValueType::StringValue("John Doe".to_string())),
+                    }),
+                })),
+            }),
+            limit: None,
+        };
+        let docs = DbStore::run_query(db.as_ref(), &db_id, &query).unwrap();
+        assert_eq!(1, docs.len());
+        let document = bson_util::bytes_to_bson_document(docs[0].doc.clone()).unwrap();
+        assert_eq!("Mike", document.get_str("name").unwrap());
+
+        // run query: select * from collection where name >= "John Doe"
+        let query = StructuredQuery {
+            collection_name: collection_name.to_string(),
+            select: Some(Projection { fields: vec![] }),
+            r#where: Some(Filter {
+                filter_type: Some(FilterType::FieldFilter(FieldFilter {
+                    field: "name".to_string(),
+                    op: Operator::GreaterThanOrEqual.into(),
+                    value: Some(Value {
+                        value_type: Some(ValueType::StringValue("John Doe".to_string())),
+                    }),
+                })),
+            }),
+            limit: None,
+        };
+        let docs = DbStore::run_query(db.as_ref(), &db_id, &query).unwrap();
+        assert_eq!(2, docs.len());
+        let document = bson_util::bytes_to_bson_document(docs[0].doc.clone()).unwrap();
+        assert_eq!("John Doe", document.get_str("name").unwrap());
+        let document = bson_util::bytes_to_bson_document(docs[1].doc.clone()).unwrap();
+        assert_eq!("Mike", document.get_str("name").unwrap());
+
+        // run query: select * from collection where name > "Mike"
+        let query = StructuredQuery {
+            collection_name: collection_name.to_string(),
+            select: Some(Projection { fields: vec![] }),
+            r#where: Some(Filter {
+                filter_type: Some(FilterType::FieldFilter(FieldFilter {
+                    field: "name".to_string(),
+                    op: Operator::GreaterThan.into(),
+                    value: Some(Value {
+                        value_type: Some(ValueType::StringValue("Mike".to_string())),
+                    }),
+                })),
+            }),
+            limit: None,
+        };
+        let docs = DbStore::run_query(db.as_ref(), &db_id, &query).unwrap();
+        assert_eq!(0, docs.len());
 
         // run query: select * from collection where name = "Bill" limit 1
         let query = StructuredQuery {
@@ -1867,7 +2037,6 @@ mod tests {
             block_id,
             mutation_id,
         );
-        println!("{:?}", res);
         assert!(res.is_err(), "{:?}", res);
         assert_eq!(
             r#"DocumentNotExist("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==")"#,
@@ -1902,7 +2071,6 @@ mod tests {
             block_id,
             mutation_id,
         );
-        println!("{:?}", res);
         assert!(res.is_err(), "{:?}", res);
         assert_eq!(
             r#"ApplyDocumentError("invalid update document mutation, ids and masks size different")"#,
@@ -2060,6 +2228,156 @@ mod tests {
                 .is_some());
         } else {
             assert!(false);
+        }
+    }
+
+    #[test]
+    fn generate_range_with_single_field_filter_test() {
+        let collection_id = CollectionId::create(1000, 100, 10).unwrap();
+
+        let index_field_name = IndexField {
+            field_path: "name".to_string(),
+            value_mode: Some(ValueMode::Order(Order::Ascending as i32)),
+        };
+
+        let index_name = Index {
+            id: 0,
+            name: "idx1".to_string(),
+            fields: vec![index_field_name],
+        };
+        let key = bson_util::bson_into_comparison_bytes(&Bson::String("Bill".to_string())).unwrap();
+
+        let res = DbStore::generate_range_with_single_field_filter(
+            &collection_id,
+            &index_name,
+            &key,
+            Some(Operator::Equal),
+        );
+        assert!(res.is_ok(), "{:?}", res);
+        let (start, end) = res.unwrap();
+        // range [collection-index-key-00000000, collection-index-key-11111111]
+        match start {
+            Included(start) => {
+                assert_eq!(start.get_document_id().unwrap(), DocumentId::zero());
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+        match end {
+            Included(start) => {
+                assert_eq!(start.get_document_id().unwrap(), DocumentId::one());
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+
+        let res = DbStore::generate_range_with_single_field_filter(
+            &collection_id,
+            &index_name,
+            &key,
+            Some(Operator::GreaterThan),
+        );
+        assert!(res.is_ok(), "{:?}", res);
+        let (start, end) = res.unwrap();
+        // range (collection-index-key-11111111, collection-next_index-0-00000000)
+        match start {
+            Excluded(start) => {
+                assert_eq!(start.get_document_id().unwrap(), DocumentId::one());
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+        match end {
+            Excluded(end) => {
+                assert_eq!(end.get_document_id().unwrap(), DocumentId::zero());
+                assert_eq!(end.get_index_field_id(), index_name.id + 1);
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+
+        let res = DbStore::generate_range_with_single_field_filter(
+            &collection_id,
+            &index_name,
+            &key,
+            Some(Operator::GreaterThanOrEqual),
+        );
+        assert!(res.is_ok(), "{:?}", res);
+        let (start, end) = res.unwrap();
+        // range [collection-index-key-00000000, collection-next_index-0-00000000)
+        match start {
+            Included(start) => {
+                assert_eq!(start.get_document_id().unwrap(), DocumentId::zero());
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+        match end {
+            Excluded(end) => {
+                assert_eq!(end.get_document_id().unwrap(), DocumentId::zero());
+                assert_eq!(end.get_index_field_id(), index_name.id + 1);
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+
+        let res = DbStore::generate_range_with_single_field_filter(
+            &collection_id,
+            &index_name,
+            &key,
+            Some(Operator::LessThan),
+        );
+        assert!(res.is_ok(), "{:?}", res);
+        let (start, end) = res.unwrap();
+        // range [collection-index-0-00000000, collection-index-key-00000000)
+        match end {
+            Excluded(end) => {
+                assert_eq!(end.get_document_id().unwrap(), DocumentId::zero());
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+
+        match start {
+            Included(start) => {
+                assert_eq!(start.get_document_id().unwrap(), DocumentId::zero());
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+
+        let res = DbStore::generate_range_with_single_field_filter(
+            &collection_id,
+            &index_name,
+            &key,
+            Some(Operator::LessThanOrEqual),
+        );
+        assert!(res.is_ok(), "{:?}", res);
+        let (start, end) = res.unwrap();
+        // range [collection-index-0-00000000, collection-index-key-11111111]
+        match end {
+            Included(end) => {
+                assert_eq!(end.get_document_id().unwrap(), DocumentId::one());
+            }
+            _ => {
+                assert!(false);
+            }
+        }
+        match start {
+            Included(start) => {
+                assert_eq!(start.get_document_id().unwrap(), DocumentId::zero());
+            }
+            _ => {
+                assert!(false);
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
Resolve #404 
We have implemented execute_query with IndexId range in #408 , in this pr, we are going to implement query with more filter operators.

- Implement `>, >=, <, <=` filter operator in run query
- Support `>, >=, <, <=` filter operator in cmd cli.
