### PR TITLE
resolve the labeler error bug if a contributor does not belong to db3 teams 

### DIFF
--- a/.github/workflows/pr_labeler.yml
+++ b/.github/workflows/pr_labeler.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: codelytv/pr-size-labeler@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.CR_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           s_label: 'PR-size-small'
           s_max_size: '100'
           m_label: 'PR-size-medium'


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
