### PR TITLE
disable multi-key index

### DIFF
--- a/src/cmd/src/command.rs
+++ b/src/cmd/src/command.rs
@@ -512,6 +512,12 @@ impl DB3ClientCommand {
                         bson_util::json_str_to_index(index_list[idx].as_str(), idx as u32).unwrap(),
                     );
                 }
+                // we currently only support index filter single field
+                for index in index_vec.iter() {
+                    if index.fields.len() != 1 {
+                        return Err("fail to create collection with multi-key index".to_string());
+                    }
+                }
                 let collection = CollectionMutation {
                     index: index_vec.to_owned(),
                     collection_name: name.to_string(),


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

### Background

we currently do not support multi-key index like `"fields":[{"field_path":"name","value_mode":{"Order":1}},{"field_path":"bio","value_mode":{"Order":2}}]}`.

### Changes
In this Cr, we are going to disable multi-key index by return error message


resolve #420 

### Demo
```
@db3.network🚀🚀🚀
db3>-$ init
 address                                    | scheme
--------------------------------------------+-----------
 0x84b0bd55e7ad979b7cb92a56f561190de8f68403 | secp256k1
db3>-$ new-db
 database address                           | mutation id
--------------------------------------------+----------------------------------------------
 0xcfbccab8fb0f18d39dff3a9c1330228c9cd213c9 | zIns1tY1ePyVF7x5O1BPb2kxUW8lZzvrkAjAcgFrj74=


db3>-$ new-collection  --addr 0xcfbccab8fb0f18d39dff3a9c1330228c9cd213c9 --name userinfo  --index '{"id": 1,"name": "idx1","fields": [{"field_path": "name","value_mode": {"Order": 1}},{"field_path": "bio","value_mode": {"Order": 2}}]}'

"fail to create collection with multi-key index"
```