### PR TITLE
support composite filter with and and eq

### DIFF
--- a/src/proto/proto/db3_database.proto
+++ b/src/proto/proto/db3_database.proto
@@ -149,8 +149,7 @@ message StructuredQuery {
       // A filter on a document field.
       FieldFilter field_filter = 1;
       // A composite filter.
-      // TODO: Support in the future P2
-      // CompositeFilter composite_filter = 2;
+      CompositeFilter composite_filter = 2;
 
       // A filter that takes exactly one argument.
       // TODO: Support in the future P1
@@ -158,6 +157,31 @@ message StructuredQuery {
     }
   }
 
+  // A filter that merges multiple other filters using the given operator.
+  message CompositeFilter {
+    // A composite filter operator.
+    enum Operator {
+      // Unspecified. This value must not be used.
+      OPERATOR_UNSPECIFIED = 0;
+
+      // Documents are required to satisfy all of the combined filters.
+      AND = 1;
+
+      // Documents are required to satisfy at least one of the combined filters.
+      // TODO: support or in the P1
+      // OR = 2;
+    }
+
+    // The operator for combining multiple filters.
+    Operator op = 1;
+
+    // The list of filters to combine.
+    //
+    // Requires:
+    //
+    // * At least one filter is present.
+    repeated Filter filters = 2;
+  }
   // A message that can hold any of the supported value types.
   message Value {
     // Must have a value set.


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

resolve https://github.com/dbpunk-labs/db3/issues/423
#### Changes
- support composite filter proto
- support filter with multi key index and equal operator
- non-support `>,>=,<=,<` filter condition