### PR TITLE
Feat/console composite filter

### DIFF
--- a/src/cmd/src/command.rs
+++ b/src/cmd/src/command.rs
@@ -513,11 +513,11 @@ impl DB3ClientCommand {
                     );
                 }
                 // we currently only support index filter single field
-                for index in index_vec.iter() {
-                    if index.fields.len() != 1 {
-                        return Err("fail to create collection with multi-key index".to_string());
-                    }
-                }
+                // for index in index_vec.iter() {
+                //     if index.fields.len() != 1 {
+                //         return Err("fail to create collection with multi-key index".to_string());
+                //     }
+                // }
                 let collection = CollectionMutation {
                     index: index_vec.to_owned(),
                     collection_name: name.to_string(),

--- a/src/proto/proto/db3_database.proto
+++ b/src/proto/proto/db3_database.proto
@@ -149,8 +149,7 @@ message StructuredQuery {
       // A filter on a document field.
       FieldFilter field_filter = 1;
       // A composite filter.
-      // TODO: Support in the future P2
-      // CompositeFilter composite_filter = 2;
+      CompositeFilter composite_filter = 2;
 
       // A filter that takes exactly one argument.
       // TODO: Support in the future P1
@@ -158,6 +157,31 @@ message StructuredQuery {
     }
   }
 
+  // A filter that merges multiple other filters using the given operator.
+  message CompositeFilter {
+    // A composite filter operator.
+    enum Operator {
+      // Unspecified. This value must not be used.
+      OPERATOR_UNSPECIFIED = 0;
+
+      // Documents are required to satisfy all of the combined filters.
+      AND = 1;
+
+      // Documents are required to satisfy at least one of the combined filters.
+      // TODO: support or in the P1
+      // OR = 2;
+    }
+
+    // The operator for combining multiple filters.
+    Operator op = 1;
+
+    // The list of filters to combine.
+    //
+    // Requires:
+    //
+    // * At least one filter is present.
+    repeated Filter filters = 2;
+  }
   // A message that can hold any of the supported value types.
   message Value {
     // Must have a value set.


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

Resolve #423 
### Changes
- support filter with multiple field filters in cmd `show-doc --addr 0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books --filter '{"and":[{"field": "name", "value": "Bill", "op": "=="},{"field": "age", "value": 44, "op": "=="}]}'`
- ONLY support multiple filters with equal conditions.
- ONLY support `and` for composite operator
### Demo
```
@db3.network🚀🚀🚀
db3>-$ init
 address                                    | scheme
--------------------------------------------+-----------
 0x84b0bd55e7ad979b7cb92a56f561190de8f68403 | secp256k1
db3>-$ new-db
 database address                           | mutation id
--------------------------------------------+----------------------------------------------
 0xc002361d5a56714200024a52ee1d8ae0700407c0 | NXJOrXgvrmmdlYsBDrH4pxxg84R9M1odWEmDqG7IJ10=
db3>-$ new-collection --addr 0xc002361d5a56714200024a52ee1d8ae0700407c0 --name books --index '{"name":"idx_name_age","fields":[{"field_path":"name","value_mode":{"Order":1}},{"field_path":"age","value_mode":{"Order":1}}]}'
send add collection done!
 mutation_id
----------------------------------------------
 Yt5iuCL8qJr9CGaHLh13zGXHhFN4JUq0q4HK/QaxaD0=
db3>-$ show-collection --addr 0xc002361d5a56714200024a52ee1d8ae0700407c0
 name  | index
-------+----------------------------------------------------------------------------------------------------------------------------------------
 books | {"name":"idx_name_age","id":0,"fields":[{"field_path":"name","value_mode":{"Order":1}},{"field_path":"age","value_mode":{"Order":1}}]}
db3>-$ new-doc --addr  0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books --documents '{"name": "John Doe","age": 43,"phones": ["+44 1234567","+44 2345678"]}'
send add document done
 mutation id
----------------------------------------------
 YNSrZsUMv/l7o9LLp8j1v7dtijUwLv5AwGHVSN+1kEQ=
db3>-$ new-doc --addr  0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books --documents '{"name": "Bill","age": 44,"phones": ["+44 1234567","+44 2345678"]}'
send add document done
 mutation id
----------------------------------------------
 LgTZVSSrk6b442rYhItR6ZXhNJSOWzHe27C1VXn1xN8=
db3>-$ new-doc --addr  0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books --documents '{"name": "Bill","age": 45,"phones": ["+44 1234567","+44 2345678"]}'
send add document done
 mutation id
----------------------------------------------
 gpEpNOKRQ0hpsktrmemsWrvAuqfFTph8kyarDfiYpOk=
db3>-$ show-doc --addr 0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books
 id_base64                            | owner                                      | document                                                                                                                  | mutation_id
--------------------------------------+--------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+----------------------------------------------
 AQAAAAAAAAB3AAEAAQAAAAAAAACMAAEAAA== | 0x84b0bd55e7ad979b7cb92a56f561190de8f68403 | Document({"name": String("John Doe"), "age": Int64(43), "phones": Array([String("+44 1234567"), String("+44 2345678")])}) | YNSrZsUMv/l7o9LLp8j1v7dtijUwLv5AwGHVSN+1kEQ=
 AQAAAAAAAAB3AAEAAQAAAAAAAACcAAEAAA== | 0x84b0bd55e7ad979b7cb92a56f561190de8f68403 | Document({"name": String("Bill"), "age": Int64(44), "phones": Array([String("+44 1234567"), String("+44 2345678")])})     | LgTZVSSrk6b442rYhItR6ZXhNJSOWzHe27C1VXn1xN8=
 AQAAAAAAAAB3AAEAAQAAAAAAAACfAAEAAA== | 0x84b0bd55e7ad979b7cb92a56f561190de8f68403 | Document({"name": String("Bill"), "age": Int64(45), "phones": Array([String("+44 1234567"), String("+44 2345678")])})     | gpEpNOKRQ0hpsktrmemsWrvAuqfFTph8kyarDfiYpOk=

db3>-$ show-doc --addr 0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books --filter '{"and":[{"field": "name", "value": "Bill", "op": "=="},{"field": "age", "value": 44, "op": "=="}]}'
 id_base64                            | owner                                      | document                                                                                                              | mutation_id
--------------------------------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+----------------------------------------------
 AQAAAAAAAAB3AAEAAQAAAAAAAACcAAEAAA== | 0x84b0bd55e7ad979b7cb92a56f561190de8f68403 | Document({"name": String("Bill"), "age": Int64(44), "phones": Array([String("+44 1234567"), String("+44 2345678")])}) | LgTZVSSrk6b442rYhItR6ZXhNJSOWzHe27C1VXn1xN8=
db3>-$ show-doc --addr 0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books --filter '{"and":[{"field": "name", "value": "Bill", "op": "=="},{"field": "age", "value": 45, "op": "=="}]}'
 id_base64                            | owner                                      | document                                                                                                              | mutation_id
--------------------------------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------------------------+----------------------------------------------
 AQAAAAAAAAB3AAEAAQAAAAAAAACfAAEAAA== | 0x84b0bd55e7ad979b7cb92a56f561190de8f68403 | Document({"name": String("Bill"), "age": Int64(45), "phones": Array([String("+44 1234567"), String("+44 2345678")])}) | gpEpNOKRQ0hpsktrmemsWrvAuqfFTph8kyarDfiYpOk=
db3>-$ show-doc --addr 0xc002361d5a56714200024a52ee1d8ae0700407c0 --collection-name books --filter '{"and":[{"field": "name", "value": "Bill", "op": "=="},{"field": "age", "value": 45, "op": "<="}]}'
"InvalidFilterJson(\"<= is not support in composite filter\")"
db3>-$
```

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for composite filters in the database query system, and also includes some refactoring and cleanup.

### Detailed summary
- Adds support for composite filters in the database query system
- Refactors and cleans up code in several files
- Removes support for multi-key indexes in the `command.rs` file

> The following files were skipped due to too many changes: `src/storage/src/db_store.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->