### PR TITLE
use storekey to encode/decode field key

### DIFF
--- a/src/crypto/Cargo.toml
+++ b/src/crypto/Cargo.toml
@@ -26,8 +26,6 @@ schemars ="0.8.10"
 serde = { version = "1.0.144", features = ["derive"] }
 serde-name = "0.2.1"
 thiserror = "1.0.34"
-#serde_bytes = "0.11.7"
-#serde_json = "1.0.88"
 bson = "2.5.0"
 serde_json = { version = "1.0.64", default-features = false }
 serde_with = "2.1.0"
@@ -43,5 +41,8 @@ rust_secp256k1 = { version = "0.24.0", package = "secp256k1", features = ["bitco
 bip32 = "0.5.0"
 ethers = { workspace = true }
 chrono = "0.4.22"
+storekey = "0.5.0"
+enum-primitive-derive = "^0.2"
+num-traits = "^0.2"
 [dev-dependencies]
 tiny-bip39 = "1.0.0"

--- a/src/crypto/src/lib.rs
+++ b/src/crypto/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(cursor_remaining)]
 //
 //
 // lib.rs
@@ -27,3 +28,5 @@ pub mod db3_verifier;
 pub mod id;
 pub mod key_derive;
 pub mod signature_scheme;
+extern crate enum_primitive_derive;
+extern crate num_traits;

--- a/src/storage/src/db3_document.rs
+++ b/src/storage/src/db3_document.rs
@@ -395,7 +395,7 @@ mod tests {
             fields: vec![index_field],
         };
         if let Ok(Some(keys)) = document.get_keys(&index) {
-            assert_eq!(vec![4, 128, 0, 0, 0, 0, 0, 0, 43], *keys.as_ref());
+            assert_eq!(vec![21, 128, 0, 0, 0, 0, 0, 0, 43], *keys.as_ref());
         } else {
             assert!(false);
         }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

Resolve #321 

As discussed in #432 https://github.com/dbpunk-labs/db3/pull/432#issuecomment-1537471645
we planed to use storekey to encode and decode key



<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for new dependencies and implements changes to `FieldKey` struct in `crypto` module. 

### Detailed summary
- Added `enum_primitive_derive` and `num_traits` dependencies to `crypto/Cargo.toml`.
- Modified `FieldKey` struct in `crypto/src/id.rs`. Changes include:
  - Added `FieldTypeId` enum.
  - Removed `encode_i32`, `decode_u32`, `encode_i64`, `decode_u64` functions.
  - Added `add_field_type`, `add_encode_field`, and `add_field` functions.
  - Modified `read_next_field` function.
- Updated `assert_eq!` in `src/storage/src/db3_document.rs`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->