### PR TITLE
db3 indexer phase 1: add indexer subscribe db3 event message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ db3.log
 /bridge/node_modules/
 /bridge/cache/
 /bridge/artifacts/
+indexer.db

--- a/src/node/src/command.rs
+++ b/src/node/src/command.rs
@@ -132,8 +132,8 @@ pub enum DB3Command {
     Indexer {
         /// the db3 storage chain grpc url
         #[clap(
-        long = "db3_storage_grpc_url",
-        default_value = "http://127.0.0.1:26659"
+            long = "db3_storage_grpc_url",
+            default_value = "http://127.0.0.1:26659"
         )]
         db3_storage_grpc_url: String,
         #[clap(short, long, default_value = "./indexer.db")]

--- a/src/node/src/command.rs
+++ b/src/node/src/command.rs
@@ -18,6 +18,7 @@
 use crate::abci_impl::AbciImpl;
 use crate::auth_storage::AuthStorage;
 use crate::context::Context;
+use crate::indexer_impl::IndexerImpl;
 use crate::json_rpc_impl;
 use crate::node_storage::NodeStorage;
 use crate::storage_node_impl::StorageNodeImpl;
@@ -124,6 +125,18 @@ pub enum DB3Command {
         /// the url of db3 grpc api
         #[clap(long = "url", global = true, default_value = "http://127.0.0.1:26659")]
         public_grpc_url: String,
+    },
+
+    /// Start db3 indexer
+    #[clap(name = "indexer")]
+    Indexer {
+        /// the url of db3 grpc api
+        #[clap(long = "url", global = true, default_value = "http://127.0.0.1:26659")]
+        public_grpc_url: String,
+        #[clap(short, long, default_value = "./indexer.db")]
+        db_path: String,
+        #[clap(long, default_value = "16")]
+        db_tree_level_in_memory: u8,
     },
 
     /// Run db3 client
@@ -391,6 +404,32 @@ impl DB3Command {
                     .unwrap();
             }
 
+            DB3Command::Indexer {
+                public_grpc_url,
+                db_path,
+                db_tree_level_in_memory,
+            } => {
+                let ctx = Self::build_context(public_grpc_url.as_ref());
+
+                let opts = Merk::default_db_opts();
+                let merk = Merk::open_opt(&db_path, opts, db_tree_level_in_memory).unwrap();
+                let node_store = Arc::new(Mutex::new(Box::pin(NodeStorage::new(
+                    AuthStorage::new(merk),
+                ))));
+                match node_store.lock() {
+                    Ok(mut store) => {
+                        if store.get_auth_store().init().is_err() {
+                            warn!("Fail to init auth storage!");
+                            return;
+                        }
+                    }
+                    _ => todo!(),
+                }
+                let mut indexer_impl = IndexerImpl::new(ctx.store_sdk.unwrap(), node_store);
+                indexer_impl.start().await.unwrap();
+                println!("exit standalone indexer")
+            }
+
             DB3Command::Client {
                 cmd,
                 public_grpc_url,
@@ -585,6 +624,7 @@ impl DB3Command {
         handler
     }
 }
+
 #[cfg(test)]
 mod tests {
     use crate::command::DB3Command;

--- a/src/node/src/indexer_impl.rs
+++ b/src/node/src/indexer_impl.rs
@@ -55,19 +55,6 @@ impl IndexerImpl {
     /// handle event message
     async fn handle_event(&mut self, event: EventMessage) -> std::result::Result<(), Status> {
         match event.event {
-            Some(event_message::Event::MutationEvent(me)) => {
-                if let Some(status_type) = MutationEventStatus::from_i32(me.status) {
-                    info!(
-                        "[Indexer] receive mutation:{:?}\t{}\t{}\t{}\t{}\t{:?}",
-                        status_type, me.height, me.sender, me.to, me.hash, me.collections
-                    );
-                } else {
-                    info!(
-                        "[Indexer] receive mutation: unknown\t{}\t{}\t{}\t{}\t{:?}",
-                        me.height, me.sender, me.to, me.hash, me.collections
-                    );
-                }
-            }
             Some(event_message::Event::BlockEvent(be)) => {
                 info!(
                     "Block\t{}\t0x{}\t0x{}\t{}",

--- a/src/node/src/indexer_impl.rs
+++ b/src/node/src/indexer_impl.rs
@@ -10,7 +10,7 @@ use db3_sdk::store_sdk::StoreSDK;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use tonic::Status;
-
+use tracing::info;
 pub struct IndexerImpl {
     store_sdk: StoreSDK,
     node_store: Arc<Mutex<Pin<Box<NodeStorage>>>>,
@@ -33,18 +33,18 @@ impl IndexerImpl {
     /// 1. subscribe db3 event
     /// 2. handle event
     pub async fn start(&mut self) -> std::result::Result<(), Status> {
-        println!("[Indexer] start indexer ...");
-        println!("[Indexer] subscribe event from db3 network");
+        info!("[Indexer] start indexer ...");
+        info!("[Indexer] subscribe event from db3 network");
         let mut stream = self
             .store_sdk
             .subscribe_event_message(true)
             .await?
             .into_inner();
-        println!("listen and handle event message");
+        info!("listen and handle event message");
         while let Some(event) = stream.message().await? {
             match self.handle_event(event).await {
                 Err(e) => {
-                    println!("[Indexer] handle event error: {:?}", e);
+                    info!("[Indexer] handle event error: {:?}", e);
                 }
                 _ => {}
             }
@@ -57,19 +57,19 @@ impl IndexerImpl {
         match event.event {
             Some(event_message::Event::MutationEvent(me)) => {
                 if let Some(status_type) = MutationEventStatus::from_i32(me.status) {
-                    println!(
+                    info!(
                         "[Indexer] receive mutation:{:?}\t{}\t{}\t{}\t{}\t{:?}",
                         status_type, me.height, me.sender, me.to, me.hash, me.collections
                     );
                 } else {
-                    println!(
+                    info!(
                         "[Indexer] receive mutation: unknown\t{}\t{}\t{}\t{}\t{:?}",
                         me.height, me.sender, me.to, me.hash, me.collections
                     );
                 }
             }
             Some(event_message::Event::BlockEvent(be)) => {
-                println!(
+                info!(
                     "Block\t{}\t0x{}\t0x{}\t{}",
                     be.height,
                     hex::encode(be.block_hash),

--- a/src/node/src/indexer_impl.rs
+++ b/src/node/src/indexer_impl.rs
@@ -2,6 +2,7 @@ use crate::node_storage::NodeStorage;
 use db3_cmd::command::DB3ClientContext;
 use db3_crypto::{db3_address::DB3Address as AccountAddress, id::TxId};
 use db3_proto::db3_event_proto::event_message;
+use db3_proto::db3_event_proto::mutation_event::MutationEventStatus;
 use db3_proto::db3_mutation_proto::DatabaseMutation;
 use db3_proto::db3_session_proto::QuerySessionInfo;
 use db3_sdk::store_sdk::StoreSDK;
@@ -44,10 +45,17 @@ impl IndexerImpl {
         while let Some(event) = stream.message().await? {
             match event.event {
                 Some(event_message::Event::MutationEvent(me)) => {
-                    println!(
-                        "[Indexer] receive mutation\t{}\t{}\t{}\t{}\t{:?}",
-                        me.height, me.sender, me.to, me.hash, me.collections
-                    );
+                    if let Some(status_type) = MutationEventStatus::from_i32(me.status) {
+                        println!(
+                            "[Indexer] receive mutation:{:?}\t{}\t{}\t{}\t{}\t{:?}",
+                            status_type, me.height, me.sender, me.to, me.hash, me.collections
+                        );
+                    } else {
+                        println!(
+                            "[Indexer] receive mutation: unknown\t{}\t{}\t{}\t{}\t{:?}",
+                            me.height, me.sender, me.to, me.hash, me.collections
+                        );
+                    }
                 }
                 _ => {}
             }

--- a/src/node/src/indexer_impl.rs
+++ b/src/node/src/indexer_impl.rs
@@ -1,0 +1,57 @@
+use crate::node_storage::NodeStorage;
+use db3_cmd::command::DB3ClientContext;
+use db3_crypto::{db3_address::DB3Address as AccountAddress, id::TxId};
+use db3_proto::db3_event_proto::event_message;
+use db3_proto::db3_mutation_proto::DatabaseMutation;
+use db3_proto::db3_session_proto::QuerySessionInfo;
+use db3_sdk::store_sdk::StoreSDK;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use tonic::Status;
+
+pub struct IndexerImpl {
+    store_sdk: StoreSDK,
+    node_store: Arc<Mutex<Pin<Box<NodeStorage>>>>,
+    pending_query_session:
+        Arc<Mutex<Vec<(AccountAddress, AccountAddress, TxId, QuerySessionInfo)>>>,
+    pending_databases: Arc<Mutex<Vec<(AccountAddress, DatabaseMutation, TxId)>>>,
+}
+
+impl IndexerImpl {
+    pub fn new(store_sdk: StoreSDK, node_store: Arc<Mutex<Pin<Box<NodeStorage>>>>) -> Self {
+        Self {
+            store_sdk,
+            node_store,
+            pending_query_session: Arc::new(Mutex::new(Vec::new())),
+            pending_databases: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// start standalone indexer
+    /// 1. subscribe db3 event
+    /// 2. handle event
+    pub async fn start(&mut self) -> std::result::Result<(), Status> {
+        println!("[Indexer] start indexer ...");
+        println!("[Indexer] subscribe event from db3 network");
+        // let mut stjoream = &self.db3_ctx.store_sdk.unwrap()
+        //     .subscribe_event_message(true).await?.into_inner();
+        let mut stream = self
+            .store_sdk
+            .subscribe_event_message(true)
+            .await?
+            .into_inner();
+        println!("listen and handle event message");
+        while let Some(event) = stream.message().await? {
+            match event.event {
+                Some(event_message::Event::MutationEvent(me)) => {
+                    println!(
+                        "[Indexer] receive mutation\t{}\t{}\t{}\t{}\t{:?}",
+                        me.height, me.sender, me.to, me.hash, me.collections
+                    );
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/node/src/lib.rs
+++ b/src/node/src/lib.rs
@@ -19,6 +19,7 @@ pub mod abci_impl;
 pub mod auth_storage;
 pub mod command;
 pub mod context;
+pub mod indexer_impl;
 mod json_rpc;
 pub mod json_rpc_impl;
 pub mod node_key;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

Resolve part of the work of #446 

### Problem / Goal
this is a initial of db3 indexer by adding a indexer service to listen/watch db3 event message and print them on console.

### Changes
- cmd `db3 indexer` to start db3 indexer
- indexer support subscribe db3 network
- the indexer won't affect current functionality. 

### Demo
<img width="1437" alt="image" src="https://github.com/dbpunk-labs/db3/assets/6291173/20f7169e-d76e-4666-bb0c-f197e6ce45ad">

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `IndexerImpl` struct to the codebase, which subscribes to events from the db3 network and handles them. 

### Detailed summary
- Adds `IndexerImpl` struct to handle db3 network events
- Implements `subscribe_event_message` method in `StoreSDK`
- Adds `handle_event` method to `IndexerImpl` to process events
- Adds `start` method to `IndexerImpl` to start the indexer
- Adds `Indexer` command to `DB3Command` enum in `command.rs` to run the indexer as a standalone program

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->