### PR TITLE
Feat/refactoring mutation util

### DIFF
--- a/src/node/src/indexer_impl.rs
+++ b/src/node/src/indexer_impl.rs
@@ -81,11 +81,8 @@ impl IndexerImpl {
                             vec![];
                         Self::parse_and_pending_mutations(&block.data, &mut pending_databases)
                             .await?;
-                        Self::apply_database_mutations(
-                            store.get_auth_store(),
-                            &mut pending_databases,
-                        )
-                        .await?;
+                        Self::apply_database_mutations(store.get_auth_store(), &pending_databases)
+                            .await?;
                         store.get_auth_store().commit().map_err(|e| {
                             Status::internal(format!("fail to commit database for {e}"))
                         })?;
@@ -159,7 +156,7 @@ impl IndexerImpl {
     }
     async fn apply_database_mutations(
         auth_store: &mut AuthStorage,
-        pending_databases: &mut Vec<(AccountAddress, DatabaseMutation, TxId)>,
+        pending_databases: &Vec<(AccountAddress, DatabaseMutation, TxId)>,
     ) -> std::result::Result<(), Status> {
         info!(
             "Pending database mutations queue size: {}",

--- a/src/node/src/lib.rs
+++ b/src/node/src/lib.rs
@@ -22,6 +22,7 @@ pub mod context;
 pub mod indexer_impl;
 mod json_rpc;
 pub mod json_rpc_impl;
+mod mutation_utils;
 pub mod node_key;
 pub mod node_storage;
 pub mod storage_node_impl;

--- a/src/node/src/mutation_utils.rs
+++ b/src/node/src/mutation_utils.rs
@@ -1,0 +1,99 @@
+use bytes::Bytes;
+use db3_crypto::db3_verifier;
+use db3_crypto::id::AccountId;
+use db3_error::DB3Error;
+use db3_proto::db3_mutation_proto::{
+    DatabaseMutation, MintCreditsMutation, PayloadType, WriteRequest,
+};
+use db3_proto::db3_session_proto::QuerySession;
+use ethers::core::types::Bytes as EthersBytes;
+use ethers::types::transaction::eip712::{Eip712, TypedData};
+use prost::Message;
+use std::str::FromStr;
+use tracing::warn;
+/// parse mutation
+macro_rules! parse_mutation {
+    ($func:ident, $type:ident) => {
+        pub fn $func(payload: &[u8]) -> Result<$type, DB3Error> {
+            match $type::decode(payload) {
+                Ok(dm) => match &dm.meta {
+                    Some(_) => Ok(dm),
+                    None => {
+                        warn!("no meta for mutation");
+                        Err(DB3Error::ApplyMutationError("meta is none".to_string()))
+                    }
+                },
+                Err(e) => {
+                    //TODO add event ?
+                    warn!("invalid mutation data {e}");
+                    Err(DB3Error::ApplyMutationError(
+                        "invalid mutation data".to_string(),
+                    ))
+                }
+            }
+        }
+    };
+}
+pub struct MutationUtil {}
+
+impl MutationUtil {
+    parse_mutation!(parse_database_mutation, DatabaseMutation);
+    parse_mutation!(parse_mint_credits_mutation, MintCreditsMutation);
+    parse_mutation!(parse_query_session, QuerySession);
+    /// unwrap and verify write request
+    pub fn unwrap_and_verify(
+        req: WriteRequest,
+    ) -> Result<(EthersBytes, PayloadType, AccountId), DB3Error> {
+        if req.payload_type == 3 {
+            // typed data
+            match serde_json::from_slice::<TypedData>(req.payload.as_ref()) {
+                Ok(data) => {
+                    let hashed_message = data.encode_eip712().map_err(|e| {
+                        DB3Error::ApplyMutationError(format!("invalid payload type for err {e}"))
+                    })?;
+                    let account_id = db3_verifier::DB3Verifier::verify_hashed(
+                        &hashed_message,
+                        req.signature.as_ref(),
+                    )?;
+                    if let (Some(payload), Some(payload_type)) =
+                        (data.message.get("payload"), data.message.get("payloadType"))
+                    {
+                        //TODO advoid data copy
+                        let data: EthersBytes =
+                            serde_json::from_value(payload.clone()).map_err(|e| {
+                                DB3Error::ApplyMutationError(format!(
+                                    "invalid payload type for err {e}"
+                                ))
+                            })?;
+                        let internal_data_type = i32::from_str(payload_type.as_str().ok_or(
+                            DB3Error::QuerySessionVerifyError("invalid payload type".to_string()),
+                        )?)
+                        .map_err(|e| {
+                            DB3Error::QuerySessionVerifyError(format!(
+                                "fail to convert payload type to i32 {e}"
+                            ))
+                        })?;
+                        let data_type: PayloadType = PayloadType::from_i32(internal_data_type)
+                            .ok_or(DB3Error::ApplyMutationError(
+                                "invalid payload type".to_string(),
+                            ))?;
+                        Ok((data, data_type, account_id))
+                    } else {
+                        Err(DB3Error::ApplyMutationError("bad typed data".to_string()))
+                    }
+                }
+                Err(e) => Err(DB3Error::ApplyMutationError(format!(
+                    "bad typed data for err {e}"
+                ))),
+            }
+        } else {
+            let account_id =
+                db3_verifier::DB3Verifier::verify(req.payload.as_ref(), req.signature.as_ref())?;
+            let data_type: PayloadType = PayloadType::from_i32(req.payload_type).ok_or(
+                DB3Error::ApplyMutationError("invalid payload type".to_string()),
+            )?;
+            let data = Bytes::from(req.payload);
+            Ok((EthersBytes(data), data_type, account_id))
+        }
+    }
+}

--- a/src/node/src/mutation_utils.rs
+++ b/src/node/src/mutation_utils.rs
@@ -102,11 +102,9 @@ mod tests {
     use super::*;
     use bytes::BytesMut;
     use chrono::Utc;
-    use db3_crypto::db3_address::DB3Address;
     use db3_crypto::db3_signer::Db3MultiSchemeSigner;
     use db3_proto::db3_base_proto::{BroadcastMeta, ChainId, ChainRole};
     use db3_proto::db3_mutation_proto::DatabaseAction;
-    use fastcrypto::traits::EncodeDecodeBase64;
     fn create_a_database_mutation() -> DatabaseMutation {
         let meta = BroadcastMeta {
             //TODO get from network
@@ -140,7 +138,7 @@ mod tests {
             payload: mbuf.as_ref().to_vec().to_owned(),
             payload_type: PayloadType::DatabasePayload.into(),
         };
-        let (bytes, payload_type, account_id) = MutationUtil::unwrap_and_verify(request).unwrap();
+        let (_, payload_type, _) = MutationUtil::unwrap_and_verify(request).unwrap();
         assert_eq!(PayloadType::DatabasePayload, payload_type);
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
Resolve #442 

### Changes
- Refactor mutation verify and unwrap to mutation util

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `MutationUtil` struct and moves the `unwrap_and_verify` function to it. It also removes duplicate code and simplifies the `IndexerImpl` and `AbciImpl` structs.

### Detailed summary
- Adds `MutationUtil` struct and moves `unwrap_and_verify` function to it.
- Removes duplicate code from `IndexerImpl` and `AbciImpl`.
- Simplifies code in `IndexerImpl` and `AbciImpl`.

> The following files were skipped due to too many changes: `src/node/src/abci_impl.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->