### PR TITLE
feat: add faucet state

### DIFF
--- a/src/faucet/src/faucet_node_impl.rs
+++ b/src/faucet/src/faucet_node_impl.rs
@@ -100,7 +100,7 @@ impl FaucetNodeImpl {
 impl FaucetNode for FaucetNodeImpl {
     async fn get_faucet_state(
         &self,
-        request: Request<GetFaucetStateRequest>,
+        _request: Request<GetFaucetStateRequest>,
     ) -> std::result::Result<Response<FaucetState>, Status> {
         let read_txn = self
             .db

--- a/src/faucet/src/faucet_node_impl.rs
+++ b/src/faucet/src/faucet_node_impl.rs
@@ -23,7 +23,10 @@ use ethers::{
 };
 
 use db3_error::{DB3Error, Result as DB3Result};
-use db3_proto::db3_faucet_proto::{faucet_node_server::FaucetNode, FaucetRequest, FaucetResponse};
+use db3_proto::db3_faucet_proto::{
+    faucet_node_server::FaucetNode, FaucetRequest, FaucetResponse, FaucetState,
+    GetFaucetStateRequest,
+};
 use db3_storage::faucet_store::FaucetStore;
 use hex;
 use redb::Database;
@@ -43,6 +46,7 @@ pub struct FaucetNodeConfig {
     pub node_list: Vec<String>,
     // a amount for every faucet request
     pub amount: u64,
+    pub enable_eth_fund: bool,
 }
 
 pub struct FaucetNodeImpl {
@@ -83,6 +87,7 @@ impl FaucetNodeImpl {
             erc20_address,
         })
     }
+
     fn current_seconds() -> u32 {
         match SystemTime::now().duration_since(UNIX_EPOCH) {
             Ok(n) => n.as_secs() as u32,
@@ -93,6 +98,22 @@ impl FaucetNodeImpl {
 
 #[tonic::async_trait]
 impl FaucetNode for FaucetNodeImpl {
+    async fn get_faucet_state(
+        &self,
+        request: Request<GetFaucetStateRequest>,
+    ) -> std::result::Result<Response<FaucetState>, Status> {
+        let read_txn = self
+            .db
+            .begin_read()
+            .map_err(|e| Status::internal(format!("fail to open transacion {e}")))?;
+        let (count, total_fund) = FaucetStore::get_state(read_txn)
+            .map_err(|e| Status::internal(format!("fail to open transacion {e}")))?;
+        return Ok(Response::new(FaucetState {
+            total_amount: total_fund,
+            total_address: count,
+        }));
+    }
+
     async fn faucet(
         &self,
         request: Request<FaucetRequest>,
@@ -129,19 +150,21 @@ impl FaucetNode for FaucetNodeImpl {
                 }
             }
         }
-        // 0.05 eth
-        let one_eth: u64 = 50_000_000_000_000_000;
         // send x_eth to faucet account
-        let tx = TransactionRequest::new()
-            .to(address)
-            .value(one_eth)
-            .from(self.address);
-        self.client
-            .send_transaction(tx, None)
-            .await
-            .unwrap()
-            .await
-            .unwrap();
+        if self.config.enable_eth_fund {
+            // 0.005 eth
+            let one_eth: u64 = 5_000_000_000_000_000;
+            let tx = TransactionRequest::new()
+                .to(address)
+                .value(one_eth)
+                .from(self.address);
+            self.client
+                .send_transaction(tx, None)
+                .await
+                .unwrap()
+                .await
+                .unwrap();
+        }
         let token_contract = DB3TokenContract::new(self.erc20_address, self.client.clone());
         let balance = token_contract.balance_of(self.address).call().await;
         info!("the main account balance {:?}", balance);

--- a/src/node/src/command.rs
+++ b/src/node/src/command.rs
@@ -184,6 +184,9 @@ pub enum DB3Command {
         /// Suppress all output logging (overrides --verbose).
         #[clap(short, long)]
         quiet: bool,
+        /// Send some eth to the accout that requests the db3 token
+        #[clap(long, default_value = "false")]
+        enable_eth_fund: bool,
     },
     /// Run db3 bridge
     #[clap(name = "bridge")]
@@ -295,6 +298,7 @@ impl DB3Command {
                 amount,
                 verbose,
                 quiet,
+                enable_eth_fund,
             } => {
                 let log_level = if quiet {
                     LevelFilter::OFF
@@ -322,6 +326,7 @@ impl DB3Command {
                     erc20_address: token_address,
                     node_list,
                     amount,
+                    enable_eth_fund,
                 };
                 let pk = db3_cmd::keystore::KeyStore::get_private_key(home.clone()).unwrap();
                 if let Ok(wallet) = pk.parse::<LocalWallet>() {

--- a/src/node/src/indexer_impl.rs
+++ b/src/node/src/indexer_impl.rs
@@ -190,6 +190,4 @@ impl IndexerImpl {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-}
+mod tests {}

--- a/src/proto/proto/db3_faucet.proto
+++ b/src/proto/proto/db3_faucet.proto
@@ -36,6 +36,13 @@ message FaucetResponse {
     string msg = 2;
 }
 
+message GetFaucetStateRequest {}
+message FaucetState {
+    uint64 total_amount = 1;
+    uint64 total_address = 2;
+}
+
 service FaucetNode {
     rpc Faucet(FaucetRequest) returns (FaucetResponse){}
+    rpc GetFaucetState(GetFaucetStateRequest) returns(FaucetState){}
 }

--- a/src/sdk/src/store_sdk.rs
+++ b/src/sdk/src/store_sdk.rs
@@ -773,7 +773,7 @@ mod tests {
         counter: i64,
     ) {
         let (_, signer) = sdk_test::gen_secp256k1_signer(counter);
-        let mut sdk = StoreSDK::new(client, signer, use_typed_format);
+        let sdk = StoreSDK::new(client, signer, use_typed_format);
         let res = sdk.fetch_block_by_height(1).await;
         assert!(res.is_ok(), "{:?}", res);
         let block: block::Block = serde_json::from_slice(res.unwrap().block.as_slice()).unwrap();

--- a/src/storage/src/faucet_store.rs
+++ b/src/storage/src/faucet_store.rs
@@ -21,9 +21,14 @@ use db3_error::{DB3Error, Result};
 use db3_proto::db3_faucet_proto::FaucetRecord;
 use prost::Message;
 use redb::ReadableTable;
-use redb::{TableDefinition, WriteTransaction};
+use redb::{ReadTransaction, TableDefinition, WriteTransaction};
 
 const FAUCET_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("FAUCET_TABLE");
+const ADDRESS_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("ADDRESS_TABLE");
+const TOTAL_FUND_TABLE: TableDefinition<&[u8], &[u8]> = TableDefinition::new("TOTAL_FUND_TABLE");
+
+const EMPTY_VALUE: [u8; 0] = [0; 0];
+static TOTAL_FUND_KEY: &str = "TOTAL_FUND_KEY";
 
 pub struct FaucetStore {}
 
@@ -31,9 +36,38 @@ impl FaucetStore {
     pub fn init_table(tx: WriteTransaction) -> Result<()> {
         tx.open_table(FAUCET_TABLE)
             .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
+        tx.open_table(ADDRESS_TABLE)
+            .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
+        tx.open_table(TOTAL_FUND_TABLE)
+            .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
         tx.commit()
             .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
         Ok(())
+    }
+
+    pub fn get_state(tx: ReadTransaction) -> Result<(u64, u64)> {
+        let addr_table = tx
+            .open_table(ADDRESS_TABLE)
+            .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
+        let total_unique_addr_count = addr_table
+            .len()
+            .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
+        let total_fund_table = tx
+            .open_table(TOTAL_FUND_TABLE)
+            .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
+        let value = total_fund_table
+            .get(TOTAL_FUND_KEY.as_bytes())
+            .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
+        if let Some(fund_value) = value {
+            let fixed_bytes: [u8; 8] = fund_value
+                .value()
+                .try_into()
+                .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
+            let fund_amount = u64::from_be_bytes(fixed_bytes);
+            Ok((total_unique_addr_count as u64, fund_amount))
+        } else {
+            Ok((total_unique_addr_count as u64, 0))
+        }
     }
 
     pub fn store_record(tx: WriteTransaction, addr: &[u8], ts: u32, amount: u64) -> Result<()> {
@@ -74,6 +108,46 @@ impl FaucetStore {
                 .insert(key_ref, buf.as_ref())
                 .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
         }
+
+        {
+            let mut mut_table = tx
+                .open_table(ADDRESS_TABLE)
+                .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
+            mut_table
+                .insert(addr.as_ref(), EMPTY_VALUE.as_ref())
+                .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
+        }
+
+        {
+            let mut mut_table = tx
+                .open_table(TOTAL_FUND_TABLE)
+                .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
+            let value = mut_table
+                .insert(TOTAL_FUND_KEY.as_bytes(), amount.to_be_bytes().as_ref())
+                .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
+
+            let fund = match value {
+                Some(old_value) => {
+                    let fixed_bytes: [u8; 8] = old_value
+                        .value()
+                        .try_into()
+                        .map_err(|e| DB3Error::StoreEventError(format!("{e}")))?;
+                    u64::from_be_bytes(fixed_bytes)
+                }
+                _ => 0,
+            };
+
+            if fund > 0 {
+                let new_amount = fund + amount;
+                let mut mut_table = tx
+                    .open_table(TOTAL_FUND_TABLE)
+                    .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
+                mut_table
+                    .insert(TOTAL_FUND_KEY.as_bytes(), new_amount.to_be_bytes().as_ref())
+                    .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
+            }
+        }
+
         tx.commit()
             .map_err(|e| DB3Error::StoreFaucetError(format!("{e}")))?;
         Ok(())
@@ -95,6 +169,12 @@ mod tests {
             FaucetStore::init_table(write_txn).unwrap();
         }
         {
+            let read_txn = db.begin_read().unwrap();
+            let (count, fund) = FaucetStore::get_state(read_txn).unwrap();
+            assert_eq!(count, 0);
+            assert_eq!(fund, 0);
+        }
+        {
             let addr: [u8; 20] = [1; 20];
             let write_txn = db.begin_write().unwrap();
             let result =
@@ -104,6 +184,12 @@ mod tests {
             let result =
                 FaucetStore::store_record(write_txn, &addr as &[u8], 1677040755, 10 * 1000_000_000);
             assert!(result.is_err());
+        }
+        {
+            let read_txn = db.begin_read().unwrap();
+            let (count, fund) = FaucetStore::get_state(read_txn).unwrap();
+            assert_eq!(count, 1);
+            assert_eq!(fund, 10 * 1000_000_000);
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `GetFaucetState` RPC method to the `FaucetNode` service, and a new `enable_eth_fund` flag to the `DB3Command` struct. It also includes changes to the `FaucetStore` module and other files.

### Detailed summary
- Adds a new `GetFaucetState` RPC method to the `FaucetNode` service.
- Adds a new `enable_eth_fund` flag to the `DB3Command` struct.
- Changes to the `FaucetStore` module to keep track of total unique addresses and total funds.
- Other minor changes to various files.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->