### PR TITLE
fix port for indexer

### DIFF
--- a/tools/start_localtestnet.sh
+++ b/tools/start_localtestnet.sh
@@ -72,7 +72,7 @@ sleep 1
 ./tendermint start --home node3 > tm3.log 2>&1 &
 sleep 1
 echo "start db3 indexer..."
-../target/${BUILD_MODE}/db3 indexer >indexer.log 2>&1  &
+../target/${BUILD_MODE}/db3 indexer --public-grpc-port 46639 --db3_storage_grpc_url 46659 >indexer.log 2>&1  &
 sleep 1
 
 if [[ $RUN_L1_CHAIN == 'OK' ]]; then


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
Small PR to fix the start_localtestnet

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds two new command line arguments to the `db3 indexer` command in the `start_localtestnet.sh` script.

### Detailed summary
- Added `--public-grpc-port 46639` argument to `db3 indexer` command.
- Added `--db3_storage_grpc_url 46659` argument to `db3 indexer` command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->