### PR TITLE
clean up indexer

### DIFF
--- a/tools/start_localnet.sh
+++ b/tools/start_localnet.sh
@@ -37,6 +37,11 @@ if [ -e ./bridge.db ]
 then
     rm bridge.db
 fi
+# clean indexer
+if [ -e ./indexer ]
+then
+    rm -rf indexer
+fi
 echo "start db3 node..."
 ./tendermint init > tm.log 2>&1 
 export RUST_BACKTRACE=1


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
clean up indexer in start_localnet.sh

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a clean indexer function to the `start_localnet.sh` script.

### Detailed summary
- Added a conditional check for the existence of `./indexer` directory.
- If it exists, the script will remove it using `rm -rf indexer` command.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->