### PR TITLE
feat: add garbage collection function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ fastcrypto = {git = "https://github.com/MystenLabs/fastcrypto", rev = "306465d4f
 ethers = {git="https://github.com/imotai/ethers-rs", rev="d526191b7972e8cf4412fee8b71cbf42e0ce7995"}
 tonic = {git="https://github.com/hyperium/tonic", rev="ae7580160431cd25c1eecda4c85014ef6ce8d93f"}
 tonic-web = {git="https://github.com/hyperium/tonic", rev="ae7580160431cd25c1eecda4c85014ef6ce8d93f"}
-arweave-rs = {git="https://github.com/imotai/arweave-rs", rev="950247ad18e0a338925d858bf3a2a94022961826"}
+arweave-rs = {git="https://github.com/imotai/arweave-rs", rev="7ac5027305db833e4d9b62c967309d5df8fba4f2"}
 serde_json= "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ fastcrypto = {git = "https://github.com/MystenLabs/fastcrypto", rev = "306465d4f
 ethers = {git="https://github.com/imotai/ethers-rs", rev="d526191b7972e8cf4412fee8b71cbf42e0ce7995"}
 tonic = {git="https://github.com/hyperium/tonic", rev="ae7580160431cd25c1eecda4c85014ef6ce8d93f"}
 tonic-web = {git="https://github.com/hyperium/tonic", rev="ae7580160431cd25c1eecda4c85014ef6ce8d93f"}
-arweave-rs = {git="https://github.com/imotai/arweave-rs", rev="31d708a98e4d7199593f7554c2e184272b0bb8dd"}
+arweave-rs = {git="https://github.com/imotai/arweave-rs", rev="950247ad18e0a338925d858bf3a2a94022961826"}
 serde_json= "1.0"

--- a/src/node/src/command.rs
+++ b/src/node/src/command.rs
@@ -101,6 +101,9 @@ pub enum DB3Command {
         /// The interval of rollup
         #[clap(long, default_value = "60000")]
         rollup_interval: u64,
+        /// The min data byte size for rollup
+        #[clap(long, default_value = "102400")]
+        rollup_min_data_size: u64,
         /// The data path of rollup
         #[clap(long, default_value = "./rollup_data")]
         rollup_data_path: String,
@@ -110,6 +113,9 @@ pub enum DB3Command {
         /// The Ar wallet path
         #[clap(long, default_value = "./wallet.json")]
         ar_key_path: String,
+        /// The min gc round offset
+        #[clap(long, default_value = "8")]
+        min_gc_round_offset: u64,
     },
 
     /// Start db3 network
@@ -241,9 +247,11 @@ impl DB3Command {
                 network_id,
                 block_interval,
                 rollup_interval,
+                rollup_min_data_size,
                 rollup_data_path,
                 ar_node_url,
                 ar_key_path,
+                min_gc_round_offset,
             } => {
                 let log_level = if verbose {
                     LevelFilter::DEBUG
@@ -261,9 +269,11 @@ impl DB3Command {
                     network_id,
                     block_interval,
                     rollup_interval,
+                    rollup_min_data_size,
                     rollup_data_path.as_str(),
                     ar_node_url.as_str(),
                     ar_key_path.as_str(),
+                    min_gc_round_offset,
                 )
                 .await;
                 let running = Arc::new(AtomicBool::new(true));
@@ -441,9 +451,11 @@ impl DB3Command {
         network_id: u64,
         block_interval: u64,
         rollup_interval: u64,
+        rollup_min_data_size: u64,
         rollup_data_path: &str,
         ar_node_url: &str,
         ar_key_path: &str,
+        min_gc_round_offset: u64,
     ) {
         let addr = format!("{public_host}:{public_grpc_port}");
         let rollup_config = RollupExecutorConfig {
@@ -451,8 +463,8 @@ impl DB3Command {
             temp_data_path: rollup_data_path.to_string(),
             ar_node_url: ar_node_url.to_string(),
             ar_key_path: ar_key_path.to_string(),
-            min_rollup_size: 1024 * 1024,
-            min_gc_round_offset: 16,
+            min_rollup_size: rollup_min_data_size,
+            min_gc_round_offset,
         };
         let store_config = MutationStoreConfig {
             db_path: mutation_db_path.to_string(),

--- a/src/node/src/command.rs
+++ b/src/node/src/command.rs
@@ -474,6 +474,7 @@ impl DB3Command {
             gc_cf_name: "gc_store_cf".to_string(),
             message_max_buffer: 4 * 1024,
             scan_max_limit: 50,
+            block_state_cf_name: "block_state_cf".to_string(),
         };
         let state_config = StateStoreConfig {
             db_path: state_db_path.to_string(),

--- a/src/node/src/command.rs
+++ b/src/node/src/command.rs
@@ -451,12 +451,15 @@ impl DB3Command {
             temp_data_path: rollup_data_path.to_string(),
             ar_node_url: ar_node_url.to_string(),
             ar_key_path: ar_key_path.to_string(),
+            min_rollup_size: 1024 * 1024,
+            min_gc_round_offset: 16,
         };
         let store_config = MutationStoreConfig {
             db_path: mutation_db_path.to_string(),
             block_store_cf_name: "block_store_cf".to_string(),
             tx_store_cf_name: "tx_store_cf".to_string(),
             rollup_store_cf_name: "rollup_store_cf".to_string(),
+            gc_cf_name: "gc_store_cf".to_string(),
             message_max_buffer: 4 * 1024,
             scan_max_limit: 50,
         };

--- a/src/node/src/rollup_executor.rs
+++ b/src/node/src/rollup_executor.rs
@@ -18,11 +18,15 @@
 use arrow::array::{ArrayRef, BinaryBuilder, StringBuilder, UInt32Builder, UInt64Builder};
 use arrow::datatypes::*;
 use arrow::record_batch::RecordBatch;
-use arweave_rs::Arweave;
+use arweave_rs::crypto::base64::Base64;
+use arweave_rs::{
+    transaction::tags::{FromUtf8Strs, Tag},
+    Arweave,
+};
 use db3_base::times;
 use db3_error::{DB3Error, Result};
 use db3_proto::db3_mutation_v2_proto::{MutationBody, MutationHeader};
-use db3_proto::db3_rollup_proto::RollupRecord;
+use db3_proto::db3_rollup_proto::{RollupRecord, GcRecord};
 use db3_storage::mutation_store::MutationStore;
 use parquet::arrow::arrow_writer::ArrowWriter;
 use parquet::basic::Compression;
@@ -34,7 +38,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Instant;
 use tempdir::TempDir;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Clone)]
 pub struct RollupExecutorConfig {
@@ -43,6 +47,8 @@ pub struct RollupExecutorConfig {
     pub temp_data_path: String,
     pub ar_key_path: String,
     pub ar_node_url: String,
+    pub min_rollup_size: u64,
+    pub min_gc_round_offset: u64,
 }
 
 pub struct RollupExecutor {
@@ -50,10 +56,15 @@ pub struct RollupExecutor {
     storage: MutationStore,
     schema: SchemaRef,
     arweave: Arweave,
+    network_id: u64,
 }
 
 impl RollupExecutor {
-    pub fn new(config: RollupExecutorConfig, storage: MutationStore) -> Result<Self> {
+    pub fn new(
+        config: RollupExecutorConfig,
+        storage: MutationStore,
+        network_id: u64,
+    ) -> Result<Self> {
         let schema = Arc::new(Schema::new(vec![
             Field::new("payload", DataType::Binary, true),
             Field::new("signature", DataType::Utf8, true),
@@ -65,15 +76,18 @@ impl RollupExecutor {
         let path = Path::new(config.ar_key_path.as_str());
         let arweave = Arweave::from_keypair_path(path, arweave_url)
             .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+
         info!(
             "start rollup executor with ar account {}",
             arweave.get_wallet_address().as_str()
         );
+
         Ok(Self {
             config,
             storage,
             schema,
             arweave,
+            network_id,
         })
     }
 
@@ -127,7 +141,28 @@ impl RollupExecutor {
         Ok((meta.num_rows as u64, metadata.len()))
     }
 
-    async fn upload_data(&self, path: &Path) -> Result<(String, u64)> {
+    async fn upload(
+        &self,
+        path: &Path,
+        last_ar_tx: &str,
+        start_block: u64,
+        end_block: u64,
+    ) -> Result<(String, u64)> {
+        let app_tag: Tag<Base64> = Tag::from_utf8_strs("App-Name", "DB3 Network")
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let rollup_tx: Tag<Base64> = Tag::from_utf8_strs("Last-Rollup-Tx", last_ar_tx)
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let block_start_tag: Tag<Base64> =
+            Tag::from_utf8_strs("Start-Block", start_block.to_string().as_str())
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let block_end_tag: Tag<Base64> =
+            Tag::from_utf8_strs("End-Block", end_block.to_string().as_str())
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let file_tag: Tag<Base64> = Tag::from_utf8_strs("File-Type", "gz.parquet")
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let network_tag: Tag<Base64> =
+            Tag::from_utf8_strs("Network-Id", self.network_id.to_string().as_str())
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
         let metadata =
             std::fs::metadata(path).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
         let fee = self
@@ -135,39 +170,107 @@ impl RollupExecutor {
             .get_fee_by_size(metadata.len())
             .await
             .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
-        //TODO add app name
         self.arweave
-            .upload_file_from_path(path, vec![], fee)
+            .upload_file_from_path(
+                path,
+                vec![
+                    app_tag,
+                    rollup_tx,
+                    block_start_tag,
+                    block_end_tag,
+                    file_tag,
+                    network_tag,
+                ],
+                fee,
+            )
             .await
             .map_err(|e| DB3Error::RollupError(format!("{e}")))
     }
 
-    pub async fn process(&self) -> Result<()> {
-        let next_rollup_start_block = match self.storage.get_last_rollup_record()? {
-            Some(r) => r.end_block + 1,
-            _ => 0_u64,
+    fn gc_mutation(&self) -> Result<()> {
+        let (last_start_block, last_end_block) = match self.storage.get_last_gc_record()? {
+            Some(r) => (r.start_block, r.end_block),
+            None => (0_u64, 0_u64),
         };
+        info!("last gc block range [{}, {})", last_start_block, last_end_block);
+
+        let now = Instant::now();
+        if self
+            .storage
+            .has_enough_round_left(last_start_block, self.config.min_gc_round_offset)?
+        {
+            if let Some(r) = self.storage.get_next_rollup_record(last_start_block)? {
+                self.storage.gc_range_mutation(r.start_block, r.end_block)?;
+                let record = GcRecord {
+                    start_block: r.start_block,
+                    end_block: r.end_block,
+                    data_size: r.raw_data_size,
+                    time:times::get_current_time_in_secs(),
+                    processed_time: now.elapsed().as_secs(),
+                };
+                self.storage.add_gc_record(&record)?;
+                info!("gc mutation from block range [{}, {}) done", r.start_block, r.end_block);
+                Ok(())
+            }else {
+                // going here is not normal case
+                warn!("fail to get next rollup record with start block {}", last_start_block);
+                Ok(())
+            }
+        }else {
+            info!(
+                "not enough round to run gc"
+            );
+            Ok(())
+        }
+    }
+
+    pub async fn process(&self) -> Result<()> {
+        let (_last_start_block, last_end_block, tx) = match self.storage.get_last_rollup_record()? {
+            Some(r) => (r.start_block, r.end_block, r.arweave_tx.to_string()),
+            _ => (0_u64, 0_u64, "".to_string()),
+        };
+
         let current_block = self.storage.get_current_block()?;
-        if current_block <= next_rollup_start_block {
+        if current_block <= last_end_block + 1 {
             info!("no block to rollup");
             return Ok(());
         }
+
         let now = Instant::now();
-        info!("the next rollup start block {next_rollup_start_block} and the newest block {current_block}");
+        info!(
+            "the next rollup start block {} and the newest block {current_block}",
+            last_end_block + 1
+        );
         let mutations = self
             .storage
-            .get_range_mutations(next_rollup_start_block, current_block)?;
+            .get_range_mutations(last_end_block + 1, current_block)?;
+
         if mutations.len() <= 0 {
             info!("no block to rollup");
             return Ok(());
         }
+
         let recordbatch = self.convert_to_recordbatch(&mutations)?;
         let memory_size = recordbatch.get_array_memory_size();
+        if memory_size < self.config.min_rollup_size as usize {
+            info!(
+                "there not enough data to trigger rollup, the min_rollup_size {}",
+                self.config.min_rollup_size
+            );
+            return Ok(());
+        }
         let tmp_dir = TempDir::new_in(&self.config.temp_data_path, "compression")
             .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
-        let file_path = tmp_dir.path().join("rollup.parquet.gz");
+        let file_path = tmp_dir.path().join("rollup.gz.parquet");
         let (num_rows, size) = self.dump_recordbatch(&file_path, &recordbatch)?;
-        let (id, reward) = self.upload_data(&file_path).await?;
+        let (id, reward) = self
+            .upload(
+                &file_path,
+                tx.as_str(),
+                last_end_block + 1,
+                current_block - 1,
+            )
+            .await?;
         info!("the process rollup done with num mutations {num_rows}, raw data size {memory_size}, compress data size {size} and processed time {} id {} cost {}", now.elapsed().as_secs(),
         id.as_str(), reward
         );
@@ -180,10 +283,12 @@ impl RollupExecutor {
             time: times::get_current_time_in_secs(),
             mutation_count: num_rows,
             cost: reward,
+            start_block: last_end_block + 1,
         };
         self.storage
             .add_rollup_record(&record)
             .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        self.gc_mutation()?;
         Ok(())
     }
 }

--- a/src/node/src/rollup_executor.rs
+++ b/src/node/src/rollup_executor.rs
@@ -261,8 +261,8 @@ impl RollupExecutor {
         let memory_size = recordbatch.get_array_memory_size();
         if memory_size < self.config.min_rollup_size as usize {
             info!(
-                "there not enough data to trigger rollup, the min_rollup_size {}",
-                self.config.min_rollup_size
+                "there not enough data to trigger rollup, the min_rollup_size {}, current size {}",
+                self.config.min_rollup_size, memory_size
             );
             return Ok(());
         }

--- a/src/node/src/rollup_executor.rs
+++ b/src/node/src/rollup_executor.rs
@@ -150,8 +150,11 @@ impl RollupExecutor {
     ) -> Result<(String, u64)> {
         let app_tag: Tag<Base64> = Tag::from_utf8_strs("App-Name", "DB3 Network")
             .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
-        let rollup_tx: Tag<Base64> = Tag::from_utf8_strs("Last-Rollup-Tx", last_ar_tx)
+        let value =
+            Base64::from_str(last_ar_tx).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let name = Base64::from_utf8_str("Last-Rollup-Tx")
             .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let last_rollup_tx = Tag::<Base64> { value, name };
         let block_start_tag: Tag<Base64> =
             Tag::from_utf8_strs("Start-Block", start_block.to_string().as_str())
                 .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
@@ -175,11 +178,11 @@ impl RollupExecutor {
                 path,
                 vec![
                     app_tag,
-                    rollup_tx,
                     block_start_tag,
                     block_end_tag,
                     file_tag,
                     network_tag,
+                    last_rollup_tx,
                 ],
                 fee,
             )
@@ -234,7 +237,7 @@ impl RollupExecutor {
     pub async fn process(&self) -> Result<()> {
         let (_last_start_block, last_end_block, tx) = match self.storage.get_last_rollup_record()? {
             Some(r) => (r.start_block, r.end_block, r.arweave_tx.to_string()),
-            _ => (0_u64, 0_u64, "".to_string()),
+            _ => (0_u64, 0_u64, "Tg==".to_string()),
         };
 
         let current_block = self.storage.get_current_block()?;

--- a/src/node/src/rollup_executor.rs
+++ b/src/node/src/rollup_executor.rs
@@ -26,7 +26,7 @@ use arweave_rs::{
 use db3_base::times;
 use db3_error::{DB3Error, Result};
 use db3_proto::db3_mutation_v2_proto::{MutationBody, MutationHeader};
-use db3_proto::db3_rollup_proto::{RollupRecord, GcRecord};
+use db3_proto::db3_rollup_proto::{GcRecord, RollupRecord};
 use db3_storage::mutation_store::MutationStore;
 use parquet::arrow::arrow_writer::ArrowWriter;
 use parquet::basic::Compression;
@@ -192,7 +192,10 @@ impl RollupExecutor {
             Some(r) => (r.start_block, r.end_block),
             None => (0_u64, 0_u64),
         };
-        info!("last gc block range [{}, {})", last_start_block, last_end_block);
+        info!(
+            "last gc block range [{}, {})",
+            last_start_block, last_end_block
+        );
 
         let now = Instant::now();
         if self
@@ -205,21 +208,25 @@ impl RollupExecutor {
                     start_block: r.start_block,
                     end_block: r.end_block,
                     data_size: r.raw_data_size,
-                    time:times::get_current_time_in_secs(),
+                    time: times::get_current_time_in_secs(),
                     processed_time: now.elapsed().as_secs(),
                 };
                 self.storage.add_gc_record(&record)?;
-                info!("gc mutation from block range [{}, {}) done", r.start_block, r.end_block);
+                info!(
+                    "gc mutation from block range [{}, {}) done",
+                    r.start_block, r.end_block
+                );
                 Ok(())
-            }else {
+            } else {
                 // going here is not normal case
-                warn!("fail to get next rollup record with start block {}", last_start_block);
+                warn!(
+                    "fail to get next rollup record with start block {}",
+                    last_start_block
+                );
                 Ok(())
             }
-        }else {
-            info!(
-                "not enough round to run gc"
-            );
+        } else {
+            info!("not enough round to run gc");
             Ok(())
         }
     }

--- a/src/node/src/storage_node_light_impl.rs
+++ b/src/node/src/storage_node_light_impl.rs
@@ -96,11 +96,12 @@ impl StorageNodeV2Impl {
         let local_running = self.running.clone();
         let local_storage = self.storage.clone();
         let rollup_config = self.config.rollup_config.clone();
+        let network_id = self.config.network_id;
         task::spawn(async move {
             info!("start the rollup thread");
             let rollup_interval = rollup_config.rollup_interval;
             //TODO handle err
-            let executor = RollupExecutor::new(rollup_config, local_storage).unwrap();
+            let executor = RollupExecutor::new(rollup_config, local_storage, network_id).unwrap();
             while local_running.load(Ordering::Relaxed) {
                 sleep(TokioDuration::from_millis(rollup_interval)).await;
                 match executor.process().await {

--- a/src/node/src/storage_node_light_impl.rs
+++ b/src/node/src/storage_node_light_impl.rs
@@ -27,9 +27,9 @@ use db3_proto::db3_storage_proto::{
     storage_node_server::StorageNode, ExtraItem, GetCollectionOfDatabaseRequest,
     GetCollectionOfDatabaseResponse, GetDatabaseOfOwnerRequest, GetDatabaseOfOwnerResponse,
     GetMutationBodyRequest, GetMutationBodyResponse, GetMutationHeaderRequest,
-    GetMutationHeaderResponse, GetNonceRequest, GetNonceResponse, ScanMutationHeaderRequest,
-    ScanMutationHeaderResponse, ScanRollupRecordRequest, ScanRollupRecordResponse,
-    SendMutationRequest, SendMutationResponse,
+    GetMutationHeaderResponse, GetNonceRequest, GetNonceResponse, ScanGcRecordRequest,
+    ScanGcRecordResponse, ScanMutationHeaderRequest, ScanMutationHeaderResponse,
+    ScanRollupRecordRequest, ScanRollupRecordResponse, SendMutationRequest, SendMutationResponse,
 };
 use db3_storage::db_store_v2::{DBStoreV2, DBStoreV2Config};
 use db3_storage::mutation_store::{MutationStore, MutationStoreConfig};
@@ -117,6 +117,18 @@ impl StorageNodeV2Impl {
 
 #[tonic::async_trait]
 impl StorageNode for StorageNodeV2Impl {
+    async fn scan_gc_record(
+        &self,
+        request: Request<ScanGcRecordRequest>,
+    ) -> std::result::Result<Response<ScanGcRecordResponse>, Status> {
+        let r = request.into_inner();
+        let records = self
+            .storage
+            .scan_gc_records(r.start, r.limit)
+            .map_err(|e| Status::internal(format!("{e}")))?;
+        Ok(Response::new(ScanGcRecordResponse { records }))
+    }
+
     async fn get_collection_of_database(
         &self,
         request: Request<GetCollectionOfDatabaseRequest>,

--- a/src/node/src/storage_node_light_impl.rs
+++ b/src/node/src/storage_node_light_impl.rs
@@ -63,6 +63,7 @@ pub struct StorageNodeV2Impl {
 impl StorageNodeV2Impl {
     pub fn new(config: StorageNodeV2Config) -> Result<Self> {
         let storage = MutationStore::new(config.store_config.clone())?;
+        storage.recover()?;
         let state_store = StateStore::new(config.state_config.clone())?;
         let db_store = DBStoreV2::new(config.db_store_config.clone())?;
         Ok(Self {

--- a/src/proto/proto/db3_rollup.proto
+++ b/src/proto/proto/db3_rollup.proto
@@ -19,6 +19,14 @@ syntax = "proto3";
 
 package db3_rollup_proto;
 
+message GcRecord {
+  uint64 start_block = 1;
+  uint64 end_block = 2;
+  uint64 data_size = 3;
+  uint64 time = 4;
+  uint64 processed_time = 5;
+}
+
 message RollupRecord {
   uint64 end_block = 1;
   uint64 raw_data_size = 2;
@@ -28,4 +36,5 @@ message RollupRecord {
   uint64 time = 6;
   uint64 mutation_count = 7;
   uint64 cost = 8;
+  uint64 start_block = 9;
 }

--- a/src/proto/proto/db3_storage.proto
+++ b/src/proto/proto/db3_storage.proto
@@ -117,6 +117,15 @@ message GetCollectionOfDatabaseResponse {
   repeated db3_database_v2_proto.Collection collections = 1;
 }
 
+message ScanGcRecordRequest {
+  uint32 start = 1;
+  uint32 limit = 2;
+}
+
+message ScanGcRecordResponse {
+  repeated db3_rollup_proto.GcRecord records = 1;
+}
+
 service StorageNode {
   rpc SendMutation(SendMutationRequest) returns (SendMutationResponse) {}
   rpc GetNonce(GetNonceRequest) returns (GetNonceResponse) {}
@@ -126,4 +135,5 @@ service StorageNode {
   rpc ScanRollupRecord(ScanRollupRecordRequest) returns (ScanRollupRecordResponse) {}
   rpc GetDatabaseOfOwner(GetDatabaseOfOwnerRequest) returns (GetDatabaseOfOwnerResponse) {}
   rpc GetCollectionOfDatabase(GetCollectionOfDatabaseRequest) returns (GetCollectionOfDatabaseResponse) {}
+  rpc ScanGcRecord(ScanGcRecordRequest) returns (ScanGcRecordResponse) {}
 }

--- a/src/sdk/src/store_sdk_v2.rs
+++ b/src/sdk/src/store_sdk_v2.rs
@@ -16,9 +16,7 @@
 //
 
 use bytes::BytesMut;
-use chrono::Utc;
-use db3_crypto::{db3_address::DB3Address, db3_signer::Db3MultiSchemeSigner};
-use db3_proto::db3_storage_proto::event_message::Event as EventV2;
+use db3_crypto::db3_signer::Db3MultiSchemeSigner;
 use db3_proto::db3_storage_proto::{
     storage_node_client::StorageNodeClient as StorageNodeV2Client, SubscribeRequest,
 };
@@ -26,16 +24,7 @@ use db3_proto::db3_storage_proto::{
     EventMessage as EventMessageV2, EventType as EventTypeV2, Subscription as SubscriptionV2,
 };
 
-use ethers::core::types::{
-    transaction::eip712::{EIP712Domain, TypedData, Types},
-    Bytes,
-};
-
-use hex;
-use num_traits::cast::FromPrimitive;
 use prost::Message;
-use std::collections::BTreeMap;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tonic::{Status, Streaming};
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -32,3 +32,6 @@ ed = "0.3.0"
 libmdbx = "0.3.3"
 rocksdb = { version = "0.18.0"}
 timer = "0.2.0"
+arweave-rs = {workspace=true}
+url = "2.4.0"
+http = "0.2"

--- a/src/storage/src/ar_fs.rs
+++ b/src/storage/src/ar_fs.rs
@@ -1,0 +1,171 @@
+//
+// ar_fs.rs
+// Copyright (C) 2023 db3.network Author imotai <codego.me@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use arweave_rs::crypto::base64::Base64;
+use arweave_rs::currency::Currency;
+use arweave_rs::{
+    transaction::tags::{FromUtf8Strs, Tag},
+    types::TxStatus,
+    wallet::WalletInfoClient,
+    Arweave,
+};
+
+use db3_error::{DB3Error, Result};
+use http::StatusCode;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+use std::str::FromStr;
+use tracing::info;
+
+#[derive(Clone)]
+pub struct ArFileSystemConfig {
+    pub wallet_path: String,
+    pub arweave_url: String,
+}
+
+pub struct ArFileSystem {
+    arweave: Arweave,
+    wallet: WalletInfoClient,
+}
+
+impl ArFileSystem {
+    pub fn new(config: ArFileSystemConfig) -> Result<Self> {
+        let arweave_url = url::Url::from_str(config.arweave_url.as_str())
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let path = Path::new(config.wallet_path.as_str());
+        let arweave = Arweave::from_keypair_path(&path, arweave_url.clone())
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let addr = arweave.get_wallet_address();
+        info!(
+            "new ar filestore with url {} and adr {}",
+            config.arweave_url.as_str(),
+            addr.as_str()
+        );
+        let wallet = WalletInfoClient::new(arweave_url);
+        Ok(Self { arweave, wallet })
+    }
+
+    pub fn get_address(&self) -> String {
+        self.arweave.get_wallet_address()
+    }
+
+    pub async fn get_balance(&self) -> Result<Currency> {
+        let balance = self
+            .wallet
+            .balance(self.arweave.get_wallet_address().as_str())
+            .await
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let currency = Currency::from_str(balance.as_str())
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        Ok(currency)
+    }
+
+    pub async fn download_file(&self, path_to_write: &Path, tx: &str) -> Result<()> {
+        let tx_b64 = Base64::from_str(tx).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let (_status, data) = self
+            .arweave
+            .get_tx_data(&tx_b64)
+            .await
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        if let Some(d) = data {
+            let mut f =
+                File::create(path_to_write).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            f.write_all(d.as_ref())
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+
+            f.sync_all()
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            Ok(())
+        } else {
+            Err(DB3Error::RollupError("fail to download file".to_string()))
+        }
+    }
+
+    pub async fn upload_file(
+        &self,
+        path: &Path,
+        last_ar_tx: &str,
+        start_block: u64,
+        end_block: u64,
+        network_id: u64,
+        filename: &str,
+    ) -> Result<(String, u64)> {
+        let mut tags: Vec<Tag<Base64>> = {
+            let app_tag: Tag<Base64> = Tag::from_utf8_strs("App-Name", "DB3 Network")
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            let block_start_tag: Tag<Base64> =
+                Tag::from_utf8_strs("Start-Block", start_block.to_string().as_str())
+                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            let block_end_tag: Tag<Base64> =
+                Tag::from_utf8_strs("End-Block", end_block.to_string().as_str())
+                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            let filename_tag: Tag<Base64> = Tag::from_utf8_strs("File-Name", filename)
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            let network_tag: Tag<Base64> =
+                Tag::from_utf8_strs("Network-Id", network_id.to_string().as_str())
+                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            vec![
+                app_tag,
+                block_start_tag,
+                block_end_tag,
+                filename_tag,
+                network_tag,
+            ]
+        };
+
+        if !last_ar_tx.is_empty() {
+            let value =
+                Base64::from_str(last_ar_tx).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            let name = Base64::from_utf8_str("Last-Rollup-Tx")
+                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            let last_rollup_tx = Tag::<Base64> { value, name };
+            tags.push(last_rollup_tx);
+        }
+
+        let metadata =
+            std::fs::metadata(path).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let fee = self
+            .arweave
+            .get_fee_by_size(metadata.len())
+            .await
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        self.arweave
+            .upload_file_from_path(path, tags, fee)
+            .await
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))
+    }
+
+    pub async fn get_tx_status(&self, id: &str) -> Result<Option<TxStatus>> {
+        let tx_id = Base64::from_str(id).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let (code, status) = self
+            .arweave
+            .get_tx_status(&tx_id)
+            .await
+            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        if code == StatusCode::ACCEPTED {
+            Ok(None)
+        } else if code == StatusCode::OK {
+            Ok(status)
+        } else {
+            Err(DB3Error::RollupError("fail to get tx status ".to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {}

--- a/src/storage/src/collection_key.rs
+++ b/src/storage/src/collection_key.rs
@@ -33,7 +33,6 @@ pub fn build_collection_key(db_addr: &DB3Address, name: &str) -> Result<Vec<u8>>
 
 #[cfg(test)]
 mod tests {
-    use super::*;
 
     #[test]
     fn it_works() {}

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -16,6 +16,7 @@
 //
 #![feature(iter_intersperse)]
 pub mod account_store;
+pub mod ar_fs;
 pub mod bill_store;
 pub mod collection_key;
 pub mod commit_store;

--- a/src/storage/src/mutation_store.rs
+++ b/src/storage/src/mutation_store.rs
@@ -329,7 +329,7 @@ impl MutationStore {
                 self.se
                     .write(batch)
                     .map_err(|e| DB3Error::WriteStoreError(format!("{e}")))?;
-                Ok(())
+                Ok((state.block, state.order))
             }
             Err(e) => Err(DB3Error::WriteStoreError(format!("{e}"))),
         }
@@ -604,6 +604,7 @@ mod tests {
                 time: 111,
                 mutation_count: 1,
                 cost: 11111,
+                start_block: 1,
             };
             let result = store.add_rollup_record(&record);
             assert!(result.is_ok());

--- a/src/storage/src/mutation_store.rs
+++ b/src/storage/src/mutation_store.rs
@@ -87,6 +87,7 @@ impl MutationStore {
             )
             .map_err(|e| DB3Error::OpenStoreError(config.db_path.to_string(), format!("{e}")))?,
         );
+
         Ok(Self {
             config,
             se,
@@ -485,6 +486,7 @@ mod tests {
             block_store_cf_name: "cf1".to_string(),
             tx_store_cf_name: "cf2".to_string(),
             rollup_store_cf_name: "rf3".to_string(),
+            gc_cf_name: "gc".to_string(),
             message_max_buffer: 4 * 1024,
             scan_max_limit: 50,
         };
@@ -502,6 +504,7 @@ mod tests {
             block_store_cf_name: "cf1".to_string(),
             tx_store_cf_name: "cf2".to_string(),
             rollup_store_cf_name: "rf3".to_string(),
+            gc_cf_name: "gc".to_string(),
             message_max_buffer: 4 * 1024,
             scan_max_limit: 50,
         };
@@ -538,6 +541,7 @@ mod tests {
             block_store_cf_name: "cf1".to_string(),
             tx_store_cf_name: "cf2".to_string(),
             rollup_store_cf_name: "rf3".to_string(),
+            gc_cf_name: "gc".to_string(),
             message_max_buffer: 4 * 1024,
             scan_max_limit: 50,
         };
@@ -580,6 +584,7 @@ mod tests {
             block_store_cf_name: "cf1".to_string(),
             tx_store_cf_name: "cf2".to_string(),
             rollup_store_cf_name: "rf3".to_string(),
+            gc_cf_name: "gc".to_string(),
             message_max_buffer: 4 * 1024,
             scan_max_limit: 50,
         };
@@ -616,6 +621,7 @@ mod tests {
             block_store_cf_name: "cf1".to_string(),
             tx_store_cf_name: "cf2".to_string(),
             rollup_store_cf_name: "rf3".to_string(),
+            gc_cf_name: "gc".to_string(),
             message_max_buffer: 4 * 1024,
             scan_max_limit: 50,
         };


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Garbage Collection and Arweave file system, as well as other changes and improvements.

### Detailed summary
- Added `GcRecord` message to `db3_rollup.proto`
- Added `ScanGcRecord` RPC to `StorageNode`
- Added `min_gc_round_offset` flag to `DB3Command`
- Added `ar_fs` module for Arweave file system support
- Added `DownloadFile` and `UploadFile` methods to `ArFileSystem`
- Updated dependencies and removed unused imports
- Other improvements and bug fixes.

> The following files were skipped due to too many changes: `src/storage/src/ar_fs.rs`, `src/node/src/rollup_executor.rs`, `src/storage/src/mutation_store.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->