### PR TITLE
feat: add doc store

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ ethers = {git="https://github.com/imotai/ethers-rs", rev="d526191b7972e8cf4412fe
 tonic = {git="https://github.com/hyperium/tonic", rev="ae7580160431cd25c1eecda4c85014ef6ce8d93f"}
 tonic-web = {git="https://github.com/hyperium/tonic", rev="ae7580160431cd25c1eecda4c85014ef6ce8d93f"}
 arweave-rs = {git="https://github.com/imotai/arweave-rs", rev="7ac5027305db833e4d9b62c967309d5df8fba4f2"}
+ejdb2rs = {git="https://github.com/imotai/ejdb2rs", rev="c937a085eda043bd854a0ef4d3e7bb63650610d1"}
 serde_json= "1.0"

--- a/src/proto/proto/db3_database_v2.proto
+++ b/src/proto/proto/db3_database_v2.proto
@@ -54,8 +54,20 @@ message EventTable {
 message Collection {
   bytes id = 1;
   string name = 2;
-  repeated Index index_list = 3;
+  repeated Index index_fields = 3;
   bytes sender = 4;
+}
+
+enum IndexType {
+    UniqueKey = 0;
+    StringKey = 1;
+    Int64Key = 2;
+    DoubleKey = 3;
+}
+
+message Index {
+  string path = 1;
+  IndexType index_type = 2;
 }
 
 message Document {
@@ -63,100 +75,6 @@ message Document {
   bytes doc = 2;
   bytes owner = 3;
   bytes tx_id = 4;
-}
-
-message Index {
-  // A field in an index.
-  // The field_path describes which field is indexed, the value_mode describes
-  // how the field value is indexed.
-  message IndexField {
-    // The supported orderings.
-    enum Order {
-      // The ordering is unspecified. Not a valid option.
-      ORDER_UNSPECIFIED = 0;
-
-      // The field is ordered by ascending field value.
-      ASCENDING = 1;
-
-      // The field is ordered by descending field value.
-      DESCENDING = 2;
-    }
-
-    // The supported array value configurations.
-    enum ArrayConfig {
-      // The index does not support additional array queries.
-      ARRAY_CONFIG_UNSPECIFIED = 0;
-
-      // The index supports array containment queries.
-      CONTAINS = 1;
-    }
-
-    // Can be __name__.
-    // For single field indexes, this must match the name of the field or may
-    // be omitted.
-    string field_path = 1;
-
-    // How the field value is indexed.
-    oneof value_mode {
-      // Indicates that this field supports ordering by the specified order or
-      // comparing using =, !=, <, <=, >, >=.
-      Order order = 2;
-
-      // Indicates that this field supports operations on `array_value`s.
-      ArrayConfig array_config = 3;
-    }
-  }
-
-  // The state of an index. During index creation, an index will be in the
-  // `CREATING` state. If the index is created successfully, it will transition
-  // to the `READY` state. If the index creation encounters a problem, the index
-  // will transition to the `NEEDS_REPAIR` state.
-  enum State {
-    // The state is unspecified.
-    STATE_UNSPECIFIED = 0;
-
-    // The index is being created.
-    // There is an active long-running operation for the index.
-    // The index is updated when writing a document.
-    // Some index data may exist.
-    CREATING = 1;
-
-    // The index is ready to be used.
-    // The index is updated when writing a document.
-    // The index is fully populated from all stored documents it applies to.
-    READY = 2;
-
-    // The index was being created, but something went wrong.
-    // There is no active long-running operation for the index,
-    // and the most recently finished long-running operation failed.
-    // The index is not updated when writing a document.
-    // Some index data may exist.
-    // Use the google.longrunning.Operations API to determine why the operation
-    // that last attempted to create this index failed, then re-create the
-    // index.
-    NEEDS_REPAIR = 3;
-  }
-
-  // Output only. A server defined name for this index.
-  // The form of this name for composite indexes will be:
-  // `projects/{project_id}/databases/{database_id}/collectionGroups/{collection_id}/indexes/{composite_index_id}`
-  // For single field indexes, this field will be empty.
-  string name = 1;
-  // Id of the index filed in the collection
-  uint32 id = 2;
-
-  // The fields supported by this index.
-  //
-  // For composite indexes, this is always 2 or more fields.
-  // The last field entry is always for the field path `__name__`. If, on
-  // creation, `__name__` was not specified as the last field, it will be added
-  // automatically with the same direction as that of the last field defined. If
-  // the final field in a composite index is not directional, the `__name__`
-  // will be ordered ASCENDING (unless explicitly specified).
-  //
-  // For single field indexes, this will always be exactly one entry with a
-  // field path equal to the field path of the associated field.
-  repeated IndexField fields = 3;
 }
 
 // A Firestore query.

--- a/src/proto/proto/db3_mutation_v2.proto
+++ b/src/proto/proto/db3_mutation_v2.proto
@@ -27,7 +27,7 @@ message DocumentDatabaseMutation {
 }
 
 message CollectionMutation {
-  repeated db3_database_v2_proto.Index index = 1;
+  repeated db3_database_v2_proto.Index index_fields = 1;
   string collection_name = 2;
 }
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -35,3 +35,5 @@ timer = "0.2.0"
 arweave-rs = {workspace=true}
 url = "2.4.0"
 http = "0.2"
+moka = "0.11.2"
+ejdb2rs = {workspace=true}

--- a/src/storage/src/db_store_v2.rs
+++ b/src/storage/src/db_store_v2.rs
@@ -219,7 +219,7 @@ impl DBStoreV2 {
         let col = Collection {
             id: id.as_ref().to_vec(),
             name: collection.collection_name.to_string(),
-            index_list: collection.index.to_vec(),
+            index_fields: collection.index_fields.to_vec(),
             sender: sender.as_ref().to_vec(),
         };
         let mut buf = BytesMut::with_capacity(1024);
@@ -338,7 +338,7 @@ mod tests {
             assert!(false);
         }
         let collection = CollectionMutation {
-            index: vec![],
+            index_fields: vec![],
             collection_name: "col1".to_string(),
         };
         let result =

--- a/src/storage/src/doc_store.rs
+++ b/src/storage/src/doc_store.rs
@@ -1,0 +1,185 @@
+//
+// doc_store.rs
+// Copyright (C) 2023 db3.network Author imotai <codego.me@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+use db3_crypto::db3_address::DB3Address;
+use db3_crypto::id::DbId;
+use db3_error::{DB3Error, Result};
+use db3_proto::db3_database_v2_proto::{Index, IndexType};
+use db3_proto::db3_mutation_v2_proto::{CollectionMutation, DocumentDatabaseMutation};
+use ejdb2::EJDB;
+use moka::sync::Cache;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tracing::{info, warn};
+
+const EJDB_INDEX: [u8; 4] = [0x01u8, 0x04u8, 0x08u8, 0x10u8];
+#[derive(Clone)]
+pub struct DocStoreConfig {
+    pub db_root_path: String,
+    pub in_memory_db_handle_limit: u32,
+}
+
+pub struct DocStore {
+    config: DocStoreConfig,
+    dbs: Cache<Vec<u8>, Arc<Mutex<EJDB>>>,
+}
+
+impl DocStore {
+    pub fn new(config: DocStoreConfig) -> Result<Self> {
+        let dbs = Cache::new(config.in_memory_db_handle_limit as u64);
+        Ok(Self { config, dbs })
+    }
+
+    fn open_db_internal(db_root_path: String, db_addr: DB3Address) -> Option<EJDB> {
+        let db_addr_str = db_addr.to_hex();
+        info!("open database with address {}", db_addr_str.as_str());
+        let mut db = EJDB::new();
+        let mut path = PathBuf::new();
+        path.push(db_root_path.as_str());
+        path.push(db_addr_str);
+        if let Some(path_str) = path.as_path().to_str() {
+            if let Ok(_) = db.open(path_str) {
+                return Some(db);
+            }
+        }
+        warn!("fail to open db with addr {}", db_addr.to_hex());
+        None
+    }
+
+    pub fn create_database(
+        &self,
+        sender: &DB3Address,
+        nonce: u64,
+        network_id: u64,
+    ) -> Result<DB3Address> {
+        let db_addr = DbId::from((sender, nonce, network_id));
+        //ensure init the database
+        if let Some(_) = Self::open_db_internal(
+            self.config.db_root_path.to_string(),
+            db_addr.address().clone(),
+        ) {
+            Ok(db_addr.address().clone())
+        } else {
+            Err(DB3Error::WriteStoreError(
+                "fail to open database".to_string(),
+            ))
+        }
+    }
+
+    pub fn create_collection(
+        &self,
+        db_addr: &DB3Address,
+        collection: &CollectionMutation,
+    ) -> Result<()> {
+        //TODO validata the db address
+        if collection.index_fields.len() > 0 {
+            let key = db_addr.as_ref().to_vec();
+            let add_addr_clone = db_addr.clone();
+            let db_root_path = self.config.db_root_path.to_string();
+            let db_entry = self.dbs.entry(key).or_optionally_insert_with(|| {
+                if let Some(db) = Self::open_db_internal(db_root_path, add_addr_clone) {
+                    Some(Arc::new(Mutex::new(db)))
+                } else {
+                    None
+                }
+            });
+            if let Some(entry) = db_entry {
+                match entry.value().lock() {
+                    Ok(db) => {
+                        for field in &collection.index_fields {
+                            db.ensure_index(
+                                collection.collection_name.as_str(),
+                                field.path.as_str(),
+                                EJDB_INDEX[field.index_type as usize],
+                            )
+                            .map_err(|e| DB3Error::WriteStoreError(format!("{e}")))?;
+                        }
+                    }
+                    Err(_) => todo!(),
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub fn add_str_doc(&self, db_addr: &DB3Address, col_name: &str, doc: &str) -> Result<i64> {
+        // validata the db and col
+        let key = db_addr.as_ref().to_vec();
+        let add_addr_clone = db_addr.clone();
+        let db_root_path = self.config.db_root_path.to_string();
+        let db_entry = self.dbs.entry(key).or_optionally_insert_with(|| {
+            if let Some(db) = Self::open_db_internal(db_root_path, add_addr_clone) {
+                Some(Arc::new(Mutex::new(db)))
+            } else {
+                None
+            }
+        });
+        if let Some(entry) = db_entry {
+            match entry.value().lock() {
+                Ok(db) => {
+                    let id = db
+                        .put_new(col_name, &doc)
+                        .map_err(|e| DB3Error::WriteStoreError(format!("{e}")))?;
+                    Ok(id)
+                }
+                Err(_) => todo!(),
+            }
+        } else {
+            Err(DB3Error::WriteStoreError(format!(
+                "no database found with addr {}",
+                db_addr.to_hex()
+            )))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempdir::TempDir;
+
+    #[test]
+    fn test_create_ejdb_database() {
+        let tmp_dir_path = TempDir::new("new_mutation_store_path").expect("create temp dir");
+        let real_path = tmp_dir_path.path().to_str().unwrap().to_string();
+        let config = DocStoreConfig {
+            db_root_path: real_path,
+            in_memory_db_handle_limit: 16,
+        };
+        let doc_store = DocStore::new(config).unwrap();
+        let db_id_ret = doc_store.create_database(&DB3Address::ZERO, 1, 1);
+        assert!(db_id_ret.is_ok());
+        let db_id = db_id_ret.unwrap();
+        let collection = CollectionMutation {
+            index_fields: vec![Index {
+                path: "/f1".to_string(),
+                index_type: IndexType::StringKey.into(),
+            }],
+            collection_name: "col1".to_string(),
+        };
+        let result = doc_store.create_collection(&db_id, &collection);
+        assert!(result.is_ok());
+        let result = doc_store.create_collection(&db_id, &collection);
+        assert!(result.is_ok());
+        let doc_str = r#"{"test":"v1", "f1":"f1"}"#;
+        if let Ok(id) = doc_store.add_str_doc(&db_id, "col1", doc_str) {
+            println!("the doc id {id}");
+        } else {
+            assert!(false);
+        }
+    }
+}

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -26,6 +26,7 @@ pub mod db_owner_key;
 pub mod db_owner_key_v2;
 pub mod db_store;
 pub mod db_store_v2;
+pub mod doc_store;
 pub mod key;
 pub mod mutation_store;
 pub mod state_store;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for a new database library and makes changes to the document store and its dependencies. 

### Detailed summary
- Adds `ejdb2rs` to `Cargo.toml`
- Adds `doc_store.rs` to `src/storage/src/`
- Modifies `db_store_v2.rs`, `db_store.rs`, `key.rs`, `mutation_store.rs`, `state_store.rs`, and `lib.rs` to import `doc_store.rs`
- Modifies `db3_mutation_v2.proto` to change `index` to `index_fields` in `CollectionMutation` message
- Modifies `db3_database_v2.proto` to add `IndexType` and change `index_list` to `index_fields` in `Index` message
- Adds `IndexType` enum to `db3_database_v2_proto`
- Adds `Index` message to `db3_database_v2_proto`
- Adds `StructuredQuery` message to `doc_store.rs`
- Adds `DocStoreConfig` and `DocStore` structs to `doc_store.rs`
- Adds `open_db_internal`, `create_database`, `create_collection`, and `add_str_doc` methods to `DocStore`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->