### PR TITLE
support get block api in light storage

### DIFF
--- a/src/node/src/storage_node_light_impl.rs
+++ b/src/node/src/storage_node_light_impl.rs
@@ -56,7 +56,7 @@ use tokio::task;
 use tokio::time::{sleep, Duration as TokioDuration};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 pub struct StorageNodeV2Config {
     pub store_config: MutationStoreConfig,
     pub state_config: StateStoreConfig,
@@ -306,11 +306,11 @@ impl StorageNode for StorageNodeV2Impl {
             .storage
             .get_range_mutations(r.block_start, r.block_end)
             .map_err(|e| Status::internal(format!("{e}")))?;
-        mutations = mutation_header_bodys
+        let mutations = mutation_header_bodys
             .iter()
             .map(|(h, b)| block_response::MutationWrapper {
-                header: Some(h),
-                body: Some(b),
+                header: Some(h.to_owned()),
+                body: Some(b.to_owned()),
             })
             .collect();
         Ok(Response::new(BlockResponse { mutations }))

--- a/src/node/src/storage_node_light_impl.rs
+++ b/src/node/src/storage_node_light_impl.rs
@@ -24,17 +24,17 @@ use db3_error::Result;
 use db3_proto::db3_mutation_v2_proto::{
     mutation::body_wrapper::Body, MutationAction, MutationRollupStatus,
 };
+use db3_proto::db3_storage_proto::block_response;
 use db3_proto::db3_storage_proto::event_message::Event as EventV2;
 use db3_proto::db3_storage_proto::{
-    storage_node_server::StorageNode, ExtraItem, GetCollectionOfDatabaseRequest,
-    GetCollectionOfDatabaseResponse, GetDatabaseOfOwnerRequest, GetDatabaseOfOwnerResponse,
-    GetMutationBodyRequest, GetMutationBodyResponse, GetMutationHeaderRequest,
-    GetMutationHeaderResponse, GetNonceRequest, GetNonceResponse, ScanGcRecordRequest,
-    ScanGcRecordResponse, ScanMutationHeaderRequest, ScanMutationHeaderResponse,
-    ScanRollupRecordRequest, ScanRollupRecordResponse, SendMutationRequest, SendMutationResponse,
-    SubscribeRequest, BlockRequest, BlockResponse
+    storage_node_server::StorageNode, BlockRequest, BlockResponse, ExtraItem,
+    GetCollectionOfDatabaseRequest, GetCollectionOfDatabaseResponse, GetDatabaseOfOwnerRequest,
+    GetDatabaseOfOwnerResponse, GetMutationBodyRequest, GetMutationBodyResponse,
+    GetMutationHeaderRequest, GetMutationHeaderResponse, GetNonceRequest, GetNonceResponse,
+    ScanGcRecordRequest, ScanGcRecordResponse, ScanMutationHeaderRequest,
+    ScanMutationHeaderResponse, ScanRollupRecordRequest, ScanRollupRecordResponse,
+    SendMutationRequest, SendMutationResponse, SubscribeRequest,
 };
-use db3_proto::db3_storage_proto::block_response;
 
 use db3_proto::db3_storage_proto::{
     BlockEvent as BlockEventV2, EventMessage as EventMessageV2, EventType as EventTypeV2,
@@ -302,11 +302,17 @@ impl StorageNode for StorageNodeV2Impl {
         request: Request<BlockRequest>,
     ) -> std::result::Result<Response<BlockResponse>, Status> {
         let r = request.into_inner();
-        let mutation_header_bodys = self.storage.get_range_mutations(
-            r.block_start,
-            r.block_end
-        ).map_err(|e| Status::internal(format!("{e}")))?;
-        mutations = mutation_header_bodys.iter().map(|(h,b)| block_response::MutationWrapper {header: Some(h), body: Some(b)}).collect();
+        let mutation_header_bodys = self
+            .storage
+            .get_range_mutations(r.block_start, r.block_end)
+            .map_err(|e| Status::internal(format!("{e}")))?;
+        mutations = mutation_header_bodys
+            .iter()
+            .map(|(h, b)| block_response::MutationWrapper {
+                header: Some(h),
+                body: Some(b),
+            })
+            .collect();
         Ok(Response::new(BlockResponse { mutations }))
     }
 

--- a/src/proto/proto/db3_mutation_v2.proto
+++ b/src/proto/proto/db3_mutation_v2.proto
@@ -83,6 +83,10 @@ message MutationBody {
   string signature = 2;
 }
 
+message MutationHeaderBody {
+  MutationHeader header = 1;
+  MutationBody body = 2;
+}
 enum MutationAction {
   CreateDocumentDB = 0;
   AddCollection = 1;

--- a/src/proto/proto/db3_mutation_v2.proto
+++ b/src/proto/proto/db3_mutation_v2.proto
@@ -83,10 +83,6 @@ message MutationBody {
   string signature = 2;
 }
 
-message MutationHeaderBody {
-  MutationHeader header = 1;
-  MutationBody body = 2;
-}
 enum MutationAction {
   CreateDocumentDB = 0;
   AddCollection = 1;

--- a/src/proto/proto/db3_storage.proto
+++ b/src/proto/proto/db3_storage.proto
@@ -140,7 +140,17 @@ message ScanGcRecordRequest {
 message ScanGcRecordResponse {
   repeated db3_rollup_proto.GcRecord records = 1;
 }
-
+message BlockRequest {
+  uint64 block_start = 1;
+  uint64 block_end = 2;
+}
+message BlockResponse {
+  message MutationWrapper {
+    db3_mutation_v2_proto.MutationHeader header = 1;
+    db3_mutation_v2_proto.MutationBody body = 2;
+  }
+  repeated MutationWrapper mutations = 3;
+}
 service StorageNode {
   rpc SendMutation(SendMutationRequest) returns (SendMutationResponse) {}
   rpc GetNonce(GetNonceRequest) returns (GetNonceResponse) {}
@@ -152,4 +162,6 @@ service StorageNode {
   rpc GetCollectionOfDatabase(GetCollectionOfDatabaseRequest) returns (GetCollectionOfDatabaseResponse) {}
   rpc ScanGcRecord(ScanGcRecordRequest) returns (ScanGcRecordResponse) {}
   rpc Subscribe(SubscribeRequest) returns (stream EventMessage) {}
+  // method for get block
+  rpc GetBlock(BlockRequest) returns (BlockResponse) {}
 }

--- a/src/sdk/src/store_sdk_v2.rs
+++ b/src/sdk/src/store_sdk_v2.rs
@@ -21,8 +21,8 @@ use db3_proto::db3_storage_proto::{
     storage_node_client::StorageNodeClient as StorageNodeV2Client, SubscribeRequest,
 };
 use db3_proto::db3_storage_proto::{
-    EventMessage as EventMessageV2, EventType as EventTypeV2, Subscription as SubscriptionV2,
     BlockRequest as BlockRequestV2, BlockResponse as BlockResponseV2,
+    EventMessage as EventMessageV2, EventType as EventTypeV2, Subscription as SubscriptionV2,
 };
 
 use prost::Message;
@@ -64,8 +64,10 @@ impl StoreSDKV2 {
         client.subscribe(req).await
     }
 
-    pub async fn get_block_by_height(&mut self, height: u64)
-        -> Result<tonic::Response<BlockResponseV2>, Status> {
+    pub async fn get_block_by_height(
+        &mut self,
+        height: u64,
+    ) -> Result<tonic::Response<BlockResponseV2>, Status> {
         let req = BloclRequestV2 {
             block_start: height,
             block_end: height,
@@ -114,8 +116,7 @@ mod tests {
     ) {
         let (_, signer) = sdk_test::gen_secp256k1_signer(counter);
         let mut sdk = StoreSDKV2::new(client, signer);
-        let res =
-            sdk.get_block_by_height(height).await;
+        let res = sdk.get_block_by_height(height).await;
         println!("res {:?}", res);
         assert!(res.is_ok(), "{:?}", res);
     }
@@ -137,7 +138,4 @@ mod tests {
         let client = Arc::new(StorageNodeV2Client::new(channel));
         get_block_by_height_flow(client.clone(), 301, 1).await;
     }
-
-
-
 }

--- a/src/sdk/src/store_sdk_v2.rs
+++ b/src/sdk/src/store_sdk_v2.rs
@@ -68,9 +68,9 @@ impl StoreSDKV2 {
         &mut self,
         height: u64,
     ) -> Result<tonic::Response<BlockResponseV2>, Status> {
-        let req = BloclRequestV2 {
+        let req = BlockRequestV2 {
             block_start: height,
-            block_end: height,
+            block_end: height + 1,
         };
         let mut client = self.client.as_ref().clone();
         client.get_block(req).await
@@ -86,7 +86,6 @@ mod tests {
     use tonic::transport::Endpoint;
 
     async fn subscribe_event_message_flow(
-        use_typed_format: bool,
         client: Arc<StorageNodeV2Client<tonic::transport::Channel>>,
         counter: i64,
     ) {
@@ -128,7 +127,7 @@ mod tests {
         let channel = rpc_endpoint.connect_lazy();
         let client = Arc::new(StorageNodeV2Client::new(channel));
 
-        subscribe_event_message_flow(false, client.clone(), 300).await;
+        subscribe_event_message_flow(client.clone(), 300).await;
     }
     #[tokio::test]
     async fn get_block_by_height_ut() {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
Resolve #477 

### Changes
- Add GetBlock API
- Add get block by height in sdk

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `GetBlock` method to the `StorageNode` service, allowing clients to retrieve a block of mutations by height. 

### Detailed summary
- Added `BlockRequest` and `BlockResponse` messages to `db3_storage_proto`
- Added `get_block` method to `StorageNode` service
- Implemented `get_block_by_height` method in `StoreSDKV2` for client use
- Added unit test for `get_block_by_height` method in `StoreSDKV2`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->