### PR TITLE
support subscribe store mutation and apply mutation

### DIFF
--- a/src/cmd/src/command.rs
+++ b/src/cmd/src/command.rs
@@ -31,12 +31,16 @@ use db3_proto::db3_mutation_proto::{
 use db3_proto::db3_node_proto::NetworkStatus;
 use db3_sdk::mutation_sdk::MutationSDK;
 use db3_sdk::store_sdk::StoreSDK;
+use db3_sdk::store_sdk_v2::StoreSDKV2;
 use prettytable::{format, Table};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub struct DB3ClientContext {
     pub mutation_sdk: Option<MutationSDK>,
     pub store_sdk: Option<StoreSDK>,
+}
+pub struct DB3ClientContextV2 {
+    pub store_sdk: Option<StoreSDKV2>,
 }
 
 #[derive(Debug, Parser)]

--- a/src/node/src/indexer_impl.rs
+++ b/src/node/src/indexer_impl.rs
@@ -2,35 +2,44 @@ use crate::auth_storage::AuthStorage;
 use crate::mutation_utils::MutationUtil;
 use crate::node_storage::NodeStorage;
 use chrono::Utc;
+use db3_base::bson_util::{bson_document_into_bytes, bytes_to_bson_document};
 use db3_crypto::db3_address::DB3Address;
 use db3_crypto::id::{DbId, DocumentId, TxId};
-use db3_proto::db3_event_proto::event_message;
-use db3_proto::db3_event_proto::EventMessage;
 use db3_proto::db3_indexer_proto::indexer_node_server::IndexerNode;
 use db3_proto::db3_indexer_proto::{
     GetDocumentRequest, GetDocumentResponse, IndexerStatus, RunQueryRequest, RunQueryResponse,
     ShowDatabaseRequest, ShowDatabaseResponse, ShowIndexerStatusRequest,
 };
 use db3_proto::db3_mutation_proto::{DatabaseAction, DatabaseMutation, PayloadType, WriteRequest};
-use db3_sdk::store_sdk::StoreSDK;
+use db3_proto::db3_mutation_v2_proto::mutation::body_wrapper::Body;
+use db3_proto::db3_mutation_v2_proto::MutationAction;
+use db3_proto::db3_storage_proto::block_response::MutationWrapper;
+use db3_proto::db3_storage_proto::event_message;
+use db3_proto::db3_storage_proto::{
+    BlockRequest as BlockRequestV2, BlockResponse as BlockResponseV2,
+    EventMessage as EventMessageV2, EventType as EventTypeV2, Subscription as SubscriptionV2,
+};
+use db3_sdk::store_sdk_v2::StoreSDKV2;
+use db3_storage::doc_store::DocStore;
 use prost::Message;
+use std::fs;
+use std::path::Path;
 use std::pin::Pin;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
-use tendermint::block;
 use tonic::{Request, Response, Status};
 use tracing::{debug, info, warn};
 
 pub struct IndexerBlockSyncer {
-    store_sdk: StoreSDK,
-    node_store: Arc<Mutex<Pin<Box<NodeStorage>>>>,
+    store_sdk: StoreSDKV2,
+    doc_store: Arc<Mutex<Pin<Box<DocStore>>>>,
 }
 
 impl IndexerBlockSyncer {
-    pub fn new(store_sdk: StoreSDK, node_store: Arc<Mutex<Pin<Box<NodeStorage>>>>) -> Self {
+    pub fn new(store_sdk: StoreSDKV2, doc_store: Arc<Mutex<Pin<Box<DocStore>>>>) -> Self {
         Self {
             store_sdk,
-            node_store,
+            doc_store,
         }
     }
 
@@ -40,11 +49,7 @@ impl IndexerBlockSyncer {
     pub async fn start(&mut self) -> std::result::Result<(), Status> {
         info!("[IndexerBlockSyncer] start indexer ...");
         info!("[IndexerBlockSyncer] subscribe event from db3 network");
-        let mut stream = self
-            .store_sdk
-            .subscribe_event_message(true)
-            .await?
-            .into_inner();
+        let mut stream = self.store_sdk.subscribe_event_message().await?.into_inner();
         info!("listen and handle event message");
         while let Some(event) = stream.message().await.unwrap() {
             match self.handle_event(event).await {
@@ -58,48 +63,26 @@ impl IndexerBlockSyncer {
     }
 
     /// handle event message
-    async fn handle_event(&mut self, event: EventMessage) -> std::result::Result<(), Status> {
+    async fn handle_event(&mut self, event: EventMessageV2) -> std::result::Result<(), Status> {
         match event.event {
             Some(event_message::Event::BlockEvent(be)) => {
                 info!(
-                    "[IndexerBlockSyncer] Receive BlockEvent: Block\t{}\t0x{}\t0x{}\t{}",
-                    be.height,
-                    hex::encode(be.block_hash),
-                    hex::encode(be.app_hash),
-                    be.gas
+                    "[IndexerBlockSyncer] Receive BlockEvent: Block\t{}MutationCount\t{}",
+                    be.block_id, be.mutation_count,
                 );
                 let response = self
                     .store_sdk
-                    .fetch_block_by_height(be.height)
+                    .get_block_by_height(be.block_id)
                     .await
-                    .map_err(|e| Status::internal(format!("fetch block error: {:?}", e)))?;
+                    .map_err(|e| Status::internal(format!("fetch block error: {:?}", e)))?
+                    .into_inner();
 
-                debug!("Block Id: {:?}", response.block_id);
-                let block: block::Block =
-                    serde_json::from_slice(response.block.as_slice()).unwrap();
-                debug!("Block transaction size: {}", block.data.len());
-                match self.node_store.lock() {
+                let mutations = response.mutations;
+                debug!("Block mutations size: {:?}", mutations.len());
+                match self.doc_store.lock() {
                     Ok(mut store) => {
-                        store.get_auth_store().begin_block(
-                            block.header.height.value(),
-                            Utc::now().timestamp() as u64,
-                        );
-                        let mut pending_databases: Vec<(DB3Address, DatabaseMutation, TxId)> =
-                            vec![];
-                        Self::parse_and_pending_mutations(&block.data, &mut pending_databases)?;
-                        Self::apply_database_mutations(store.get_auth_store(), &pending_databases)?;
-                        store.get_auth_store().commit().map_err(|e| {
-                            Status::internal(format!("fail to commit database for {e}"))
-                        })?;
+                        Self::parse_and_apply_mutations(store.as_mut(), &mutations)?;
                         // TODO: add show indexer state api
-                        info!(
-                            "[IndexerBlockSyncer] last block state: {:?}",
-                            store.get_auth_store().get_last_block_state()
-                        );
-                        info!(
-                            "[IndexerBlockSyncer] indexer state: {:?}",
-                            store.get_auth_store().get_state()
-                        );
                     }
                     Err(e) => {
                         warn!("[IndexerBlockSyncer] get node store error: {:?}", e);
@@ -111,94 +94,110 @@ impl IndexerBlockSyncer {
         }
         Ok(())
     }
-    fn parse_and_pending_mutations(
-        txs: &Vec<Vec<u8>>,
-        database_mutations: &mut Vec<(DB3Address, DatabaseMutation, TxId)>,
+    fn parse_and_apply_mutations(
+        doc_store: Pin<&mut DocStore>,
+        mutations: &Vec<MutationWrapper>,
     ) -> Result<(), Status> {
-        for tx in txs {
-            let tx_id = TxId::from(tx.as_ref());
-            let wrequest = WriteRequest::decode(tx.as_ref());
-            match wrequest {
-                Ok(req) => match MutationUtil::unwrap_and_verify(req) {
-                    Ok((data, data_type, account_id)) => match data_type {
-                        PayloadType::DatabasePayload => {
-                            match MutationUtil::parse_database_mutation(data.as_ref()) {
-                                Ok(dm) => {
-                                    let action = DatabaseAction::from_i32(dm.action);
-                                    info!(
-                                        "Add account: {}, mutation : {:?}, tx: {} into pending queue",
-                                        account_id.addr.to_hex(), action, tx_id.to_base64());
-                                    database_mutations.push((account_id.addr, dm, tx_id));
-                                }
-                                Err(e) => {
-                                    let msg = format!("{e}");
-                                    return Err(Status::internal(msg));
-                                }
-                            }
+        for mutation in mutations.iter() {
+            let body = mutation.body.as_ref().unwrap();
+            // validate the signature
+            let (dm, address, nonce) =
+                MutationUtil::unwrap_and_light_verify(&body.payload, body.signature.as_str())
+                    .map_err(|e| Status::internal(format!("{e}")))?;
+            let action = MutationAction::from_i32(dm.action)
+                .ok_or(Status::internal("fail to convert action type".to_string()))?;
+            // TODO validate the database mutation
+            match action {
+                MutationAction::CreateDocumentDb => {
+                    for body in dm.bodies {
+                        if let Some(Body::DocDatabaseMutation(ref doc_db_mutation)) = &body.body {
+                            let db_id = doc_store
+                                .create_database(
+                                    &address, nonce,
+                                    // TODO: pass network id from config or mutation header
+                                    0,
+                                )
+                                .map_err(|e| Status::internal(format!("{e}")))?;
+                            let db_id_hex = db_id.to_hex();
+                            info!(
+                                "add database with addr {} from owner {}",
+                                db_id_hex.as_str(),
+                                address.to_hex().as_str()
+                            );
+                            break;
                         }
-                        PayloadType::QuerySessionPayload => {
-                            debug!("[IndexerBlockSyncer] Skip QuerySessionPayload");
-                        }
-                        PayloadType::MintCreditsPayload => {
-                            debug!("[IndexerBlockSyncer] Skip MintCreditsPayload");
-                        }
-                        _ => {
-                            debug!("[IndexerBlockSyncer] Skip other payload type");
-                        }
-                    },
-                    Err(e) => {
-                        warn!("[IndexerBlockSyncer] invalid write request: {:?}", e);
-                        return Err(Status::internal(format!("invalid write request: {:?}", e)));
                     }
-                },
-                Err(e) => {
-                    warn!("[IndexerBlockSyncer] invalid write request: {:?}", e);
-                    return Err(Status::internal(format!("invalid write request: {:?}", e)));
+                }
+                MutationAction::AddCollection => {
+                    for (i, body) in dm.bodies.iter().enumerate() {
+                        let db_address_ref: &[u8] = body.db_address.as_ref();
+                        let db_addr = DB3Address::try_from(db_address_ref)
+                            .map_err(|e| Status::internal(format!("{e}")))?;
+                        if let Some(Body::CollectionMutation(ref col_mutation)) = &body.body {
+                            doc_store
+                                .create_collection(&address, col_mutation)
+                                .map_err(|e| Status::internal(format!("{e}")))?;
+                            info!(
+                                    "add collection with db_addr {}, collection_name: {}, from owner {}",
+                                    db_addr.to_hex().as_str(),
+                                    col_mutation.collection_name.as_str(),
+                                    address.to_hex().as_str()
+                                );
+                        }
+                    }
+                }
+                MutationAction::AddDocument => {
+                    for (i, body) in dm.bodies.iter().enumerate() {
+                        let db_address_ref: &[u8] = body.db_address.as_ref();
+                        let db_addr = DB3Address::try_from(db_address_ref)
+                            .map_err(|e| Status::internal(format!("{e}")))?;
+                        if let Some(Body::DocumentMutation(ref doc_mutation)) = &body.body {
+                            let mut docs = Vec::<String>::new();
+                            for buf in doc_mutation.documents.iter() {
+                                let document =
+                                    bytes_to_bson_document(buf.clone()).map_err(|e| {
+                                        Status::internal(format!(
+                                            "fail to convert bytes to bson: {:?}",
+                                            e
+                                        ))
+                                    })?;
+                                let doc_str = document.to_string();
+                                debug!("add document: {}", doc_str);
+                                docs.push(doc_str.to_string());
+                            }
+                            let ids = doc_store
+                                .add_str_docs(
+                                    &address,
+                                    doc_mutation.collection_name.as_str(),
+                                    &docs,
+                                )
+                                .map_err(|e| Status::internal(format!("{e}")))?;
+                            info!(
+                                    "add documents with db_addr {}, collection_name: {}, from owner {}, ids: {:?}",
+                                    db_addr.to_hex().as_str(),
+                                    doc_mutation.collection_name.as_str(),
+                                    address.to_hex().as_str(), ids,
+                                );
+                        }
+                    }
+                }
+                _ => {
+                    warn!("unsupported mutation action: {:?}", action);
                 }
             }
         }
         Ok(())
     }
-    fn apply_database_mutations(
-        auth_store: &mut AuthStorage,
-        pending_databases: &Vec<(DB3Address, DatabaseMutation, TxId)>,
-    ) -> std::result::Result<(), Status> {
-        info!(
-            "Pending database mutations queue size: {}",
-            pending_databases.len()
-        );
-
-        for (account_addr, mutation, tx_id) in pending_databases {
-            let action = DatabaseAction::from_i32(mutation.action);
-            info!(
-                "apply database mutation transaction tx: {}, mutation: action: {:?}",
-                &tx_id.to_base64(),
-                action
-            );
-            let nonce: u64 = match &mutation.meta {
-                Some(m) => m.nonce,
-                //TODO will not go to here
-                None => 1,
-            };
-            match auth_store.apply_database(&account_addr, nonce, &tx_id, &mutation) {
-                Ok(_) => {
-                    info!("apply transaction {} success", &tx_id.to_base64());
-                }
-                Err(e) => {
-                    warn!("fail to apply database for {e}");
-                    return Err(Status::internal(format!("fail to apply database for {e}")));
-                }
-            };
-        }
-        Ok(())
-    }
 }
 pub struct IndexerNodeImpl {
-    node_store: Arc<Mutex<Pin<Box<NodeStorage>>>>,
+    doc_store: Arc<Mutex<Pin<Box<DocStore>>>>,
 }
 impl IndexerNodeImpl {
-    pub fn new(node_store: Arc<Mutex<Pin<Box<NodeStorage>>>>) -> Self {
-        Self { node_store }
+    pub fn new(db_path: &str, doc_store: Arc<Mutex<Pin<Box<DocStore>>>>) -> Self {
+        info!("open indexer store with path {}", db_path);
+        let path = Path::new(db_path);
+        fs::create_dir(path).unwrap();
+        Self { doc_store }
     }
 }
 #[tonic::async_trait]
@@ -208,16 +207,15 @@ impl IndexerNode for IndexerNodeImpl {
         &self,
         _request: Request<ShowIndexerStatusRequest>,
     ) -> Result<Response<IndexerStatus>, Status> {
-        match self.node_store.lock() {
-            Ok(node_store) => {
-                let state = node_store.get_state();
+        match self.doc_store.lock() {
+            Ok(_doc_store) => {
                 let status = IndexerStatus {
-                    total_database_count: state.total_database_count.load(Ordering::Relaxed),
-                    total_collection_count: state.total_collection_count.load(Ordering::Relaxed),
-                    total_document_count: state.total_document_count.load(Ordering::Relaxed),
-                    total_account_count: state.total_account_count.load(Ordering::Relaxed),
-                    total_mutation_count: state.total_mutation_count.load(Ordering::Relaxed),
-                    total_storage_in_bytes: state.total_storage_bytes.load(Ordering::Relaxed),
+                    total_database_count: 0,
+                    total_collection_count: 0,
+                    total_document_count: 0,
+                    total_account_count: 0,
+                    total_mutation_count: 0,
+                    total_storage_in_bytes: 0,
                 };
                 Ok(Response::new(status))
             }
@@ -225,89 +223,89 @@ impl IndexerNode for IndexerNodeImpl {
         }
     }
 
-    /// show databases info
-    async fn show_database(
-        &self,
-        request: Request<ShowDatabaseRequest>,
-    ) -> std::result::Result<Response<ShowDatabaseResponse>, Status> {
-        let show_database_req = request.into_inner();
-        match self.node_store.lock() {
-            Ok(mut node_store) => {
-                if show_database_req.address.len() > 0 {
-                    // get database id
-                    let address_ref: &str = show_database_req.address.as_ref();
-                    let db_id = DbId::try_from(address_ref)
-                        .map_err(|e| Status::internal(format!("invalid database address {e}")))?;
-                    if let Some(db) = node_store
-                        .get_auth_store()
-                        .get_database(&db_id)
-                        .map_err(|e| Status::internal(format!("{:?}", e)))?
-                    {
-                        Ok(Response::new(ShowDatabaseResponse { dbs: vec![db] }))
-                    } else {
-                        Ok(Response::new(ShowDatabaseResponse { dbs: vec![] }))
-                    }
-                } else {
-                    let address_ref: &str = show_database_req.owner_address.as_str();
-                    let owner = DB3Address::try_from(address_ref)
-                        .map_err(|e| Status::internal(format!("invalid database address {e}")))?;
-                    let dbs = node_store
-                        .get_auth_store()
-                        .get_my_database(&owner)
-                        .map_err(|e| Status::internal(format!("{:?}", e)))?;
-                    Ok(Response::new(ShowDatabaseResponse { dbs }))
-                }
-            }
-            Err(e) => Err(Status::internal(format!("Fail to get lock {}", e))),
-        }
-    }
+    // /// show databases info
+    // async fn show_database(
+    //     &self,
+    //     request: Request<ShowDatabaseRequest>,
+    // ) -> std::result::Result<Response<ShowDatabaseResponse>, Status> {
+    //     let show_database_req = request.into_inner();
+    //     match self.doc_store.lock() {
+    //         Ok(mut doc_store) => {
+    //             if show_database_req.address.len() > 0 {
+    //                 // get database id
+    //                 let address_ref: &str = show_database_req.address.as_ref();
+    //                 let db_id = DbId::try_from(address_ref)
+    //                     .map_err(|e| Status::internal(format!("invalid database address {e}")))?;
+    //                 if let Some(db) = doc_store.get
+    //                     .get_auth_store()
+    //                     .get_database(&db_id)
+    //                     .map_err(|e| Status::internal(format!("{:?}", e)))?
+    //                 {
+    //                     Ok(Response::new(ShowDatabaseResponse { dbs: vec![db] }))
+    //                 } else {
+    //                     Ok(Response::new(ShowDatabaseResponse { dbs: vec![] }))
+    //                 }
+    //             } else {
+    //                 let address_ref: &str = show_database_req.owner_address.as_str();
+    //                 let owner = DB3Address::try_from(address_ref)
+    //                     .map_err(|e| Status::internal(format!("invalid database address {e}")))?;
+    //                 let dbs = node_store
+    //                     .get_auth_store()
+    //                     .get_my_database(&owner)
+    //                     .map_err(|e| Status::internal(format!("{:?}", e)))?;
+    //                 Ok(Response::new(ShowDatabaseResponse { dbs }))
+    //             }
+    //         }
+    //         Err(e) => Err(Status::internal(format!("Fail to get lock {}", e))),
+    //     }
+    // }
 
-    /// get document with given id
-    async fn get_document(
-        &self,
-        request: Request<GetDocumentRequest>,
-    ) -> std::result::Result<Response<GetDocumentResponse>, Status> {
-        let get_document_request = request.into_inner();
-        let id = DocumentId::try_from_base64(get_document_request.id.as_str())
-            .map_err(|e| Status::internal(format!("{:?}", e)))?;
-        match self.node_store.lock() {
-            Ok(mut node_store) => {
-                // get database id
-                match node_store.get_auth_store().get_document(&id) {
-                    Ok(document) => Ok(Response::new(GetDocumentResponse { document })),
-                    Err(e) => Err(Status::internal(format!("fail to get document {:?}", e))),
-                }
-            }
-            Err(e) => Err(Status::internal(format!("Fail to get lock {}", e))),
-        }
-    }
+    // /// get document with given id
+    // async fn get_document(
+    //     &self,
+    //     request: Request<GetDocumentRequest>,
+    // ) -> std::result::Result<Response<GetDocumentResponse>, Status> {
+    //     let get_document_request = request.into_inner();
+    //     let id = DocumentId::try_from_base64(get_document_request.id.as_str())
+    //         .map_err(|e| Status::internal(format!("{:?}", e)))?;
+    //     match self.doc_store.lock() {
+    //         Ok(mut node_store) => {
+    //             // get database id
+    //             match node_store.get_auth_store().get_document(&id) {
+    //                 Ok(document) => Ok(Response::new(GetDocumentResponse { document })),
+    //                 Err(e) => Err(Status::internal(format!("fail to get document {:?}", e))),
+    //             }
+    //         }
+    //         Err(e) => Err(Status::internal(format!("Fail to get lock {}", e))),
+    //     }
+    // }
 
-    /// run document query with structure query
-    async fn run_query(
-        &self,
-        request: Request<RunQueryRequest>,
-    ) -> std::result::Result<Response<RunQueryResponse>, Status> {
-        let run_query_req = request.into_inner();
-        match self.node_store.lock() {
-            Ok(mut node_store) => {
-                // get database id
-                let address_ref: &str = run_query_req.address.as_ref();
-                let db_id = DbId::try_from(address_ref)
-                    .map_err(|e| Status::internal(format!("invalid database address {e}")))?;
-                match &run_query_req.query {
-                    Some(query) => {
-                        let documents = node_store
-                            .get_auth_store()
-                            .run_query(&db_id, &query)
-                            .map_err(|e| Status::internal(format!("{:?}", e)))?;
-                        Ok(Response::new(RunQueryResponse { documents }))
-                    }
-                    None => return Err(Status::internal("Fail to run with none query")),
-                }
-            }
-            Err(e) => Err(Status::internal(format!("Fail to get lock {}", e))),
-        }
-    }
+    // /// run document query with structure query
+    // async fn run_query(
+    //     &self,
+    //     request: Request<RunQueryRequest>,
+    // ) -> std::result::Result<Response<RunQueryResponse>, Status> {
+    //     let run_query_req = request.into_inner();
+    //     match self.doc_store.lock() {
+    //         Ok(mut node_store) => {
+    //             // get database id
+    //             let address_ref: &str = run_query_req.address.as_ref();
+    //             let db_id = DbId::try_from(address_ref)
+    //                 .map_err(|e| Status::internal(format!("invalid database address {e}")))?;
+    //             match &run_query_req.query {
+    //                 Some(query) => {
+    //                     let documents = node_store
+    //                         .get_auth_store()
+    //                         .run_query(&db_id, &query)
+    //                         .map_err(|e| Status::internal(format!("{:?}", e)))?;
+    //                     Ok(Response::new(RunQueryResponse { documents }))
+    //                 }
+    //                 None => return Err(Status::internal("Fail to run with none query")),
+    //             }
+    //         }
+    //         Err(e) => Err(Status::internal(format!("Fail to get lock {}", e))),
+    //     }
+    // }
 }
 #[cfg(test)]
 mod tests {}

--- a/src/node/src/storage_node_light_impl.rs
+++ b/src/node/src/storage_node_light_impl.rs
@@ -118,7 +118,7 @@ impl StorageNodeV2Impl {
                     "produce block {}",
                     local_storage.get_current_block().unwrap_or(0)
                 );
-                match local_storage.increase_block() {
+                match local_storage.increase_block_return_last_state() {
                     Ok((block_id, mutation_count)) => {
                         // sender block event
                         let e = BlockEventV2 {
@@ -508,6 +508,12 @@ impl StorageNode for StorageNodeV2Impl {
                                         i as u16,
                                     )
                                     .map_err(|e| Status::internal(format!("{e}")))?;
+                                info!(
+                                    "add collection with db_addr {}, collection_name: {}, from owner {}",
+                                    db_addr.to_hex().as_str(),
+                                    col_mutation.collection_name.as_str(),
+                                    address.to_hex().as_str()
+                                );
                                 let item = ExtraItem {
                                     key: "collection".to_string(),
                                     value: col_mutation.collection_name.to_string(),

--- a/src/proto/proto/db3_indexer.proto
+++ b/src/proto/proto/db3_indexer.proto
@@ -66,9 +66,9 @@ service IndexerNode {
   // method for show indexer status
   rpc ShowIndexerStatus(ShowIndexerStatusRequest) returns (IndexerStatus) {}
   // method for show database
-  rpc ShowDatabase(ShowDatabaseRequest) returns (ShowDatabaseResponse) {}
-  // method for query document
-  rpc RunQuery(RunQueryRequest) returns (RunQueryResponse) {}
-  // method for get document
-  rpc GetDocument(GetDocumentRequest) returns (GetDocumentResponse) {}
+//  rpc ShowDatabase(ShowDatabaseRequest) returns (ShowDatabaseResponse) {}
+//  // method for query document
+//  rpc RunQuery(RunQueryRequest) returns (RunQueryResponse) {}
+//  // method for get document
+//  rpc GetDocument(GetDocumentRequest) returns (GetDocumentResponse) {}
 }

--- a/src/sdk/src/indexer_sdk.rs
+++ b/src/sdk/src/indexer_sdk.rs
@@ -23,247 +23,247 @@ use db3_proto::db3_indexer_proto::{
 };
 use std::sync::Arc;
 use tonic::Status;
-
-pub struct IndexerSDK {
-    client: Arc<IndexerNodeClient<tonic::transport::Channel>>,
-}
-
-impl IndexerSDK {
-    pub fn new(client: Arc<IndexerNodeClient<tonic::transport::Channel>>) -> Self {
-        Self { client }
-    }
-
-    /// show document with given db addr and collection name
-    pub async fn list_documents(
-        &mut self,
-        addr: &str,
-        collection_name: &str,
-        limit: Option<i32>,
-    ) -> std::result::Result<RunQueryResponse, Status> {
-        self.run_query(
-            addr,
-            StructuredQuery {
-                collection_name: collection_name.to_string(),
-                limit: match limit {
-                    Some(v) => Some(Limit { limit: v }),
-                    None => None,
-                },
-                select: Some(Projection { fields: vec![] }),
-                r#where: None,
-            },
-        )
-        .await
-    }
-
-    /// get the document with a base64 format id
-    pub async fn get_document(
-        &mut self,
-        id: &str,
-    ) -> std::result::Result<Option<Document>, Status> {
-        let r = GetDocumentRequest { id: id.to_string() };
-
-        let request = tonic::Request::new(r);
-        let mut client = self.client.as_ref().clone();
-        let response = client.get_document(request).await?.into_inner();
-        Ok(response.document)
-    }
-
-    ///
-    /// get the information of database with a hex format address
-    ///
-    pub async fn get_database(
-        &mut self,
-        addr: &str,
-    ) -> std::result::Result<Option<Database>, Status> {
-        let r = ShowDatabaseRequest {
-            address: addr.to_string(),
-            owner_address: "".to_string(),
-        };
-        let request = tonic::Request::new(r);
-        let mut client = self.client.as_ref().clone();
-        let response = client.show_database(request).await?.into_inner();
-        if response.dbs.len() > 0 {
-            Ok(Some(response.dbs[0].clone()))
-        } else {
-            Ok(None)
-        }
-    }
-
-    ///
-    /// get the information of database with a hex format address
-    ///
-    pub async fn get_my_database(
-        &mut self,
-        addr: &str,
-    ) -> std::result::Result<Vec<Database>, Status> {
-        let r = ShowDatabaseRequest {
-            address: "".to_string(),
-            owner_address: addr.to_string(),
-        };
-        let request = tonic::Request::new(r);
-        let mut client = self.client.as_ref().clone();
-        let response = client.show_database(request).await?.into_inner();
-        Ok(response.dbs)
-    }
-
-    /// query the document with structure query
-    pub async fn run_query(
-        &mut self,
-        addr: &str,
-        query: StructuredQuery,
-    ) -> std::result::Result<RunQueryResponse, Status> {
-        let r = RunQueryRequest {
-            address: addr.to_string(),
-            query: Some(query),
-        };
-        let request = tonic::Request::new(r);
-        let mut client = self.client.as_ref().clone();
-        let response = client.run_query(request).await?.into_inner();
-        Ok(response)
-    }
-
-    pub async fn get_state(&self) -> std::result::Result<IndexerStatus, Status> {
-        let r = ShowIndexerStatusRequest {};
-        let request = tonic::Request::new(r);
-        let mut client = self.client.as_ref().clone();
-        let status = client.show_indexer_status(request).await?.into_inner();
-        Ok(status)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-    use crate::mutation_sdk::MutationSDK;
-    use crate::sdk_test;
-
-    use db3_proto::db3_database_proto::structured_query::field_filter::Operator;
-    use db3_proto::db3_database_proto::structured_query::filter::FilterType;
-    use db3_proto::db3_database_proto::structured_query::value::ValueType;
-    use db3_proto::db3_database_proto::structured_query::{FieldFilter, Filter, Projection, Value};
-    use db3_proto::db3_indexer_proto::indexer_node_client::IndexerNodeClient;
-    use db3_proto::db3_node_proto::storage_node_client::StorageNodeClient;
-    use std::sync::Arc;
-    use std::time;
-    use tonic::transport::Endpoint;
-
-    async fn run_doc_crud_happy_path(
-        storage_client: Arc<StorageNodeClient<tonic::transport::Channel>>,
-        indexer_client: Arc<IndexerNodeClient<tonic::transport::Channel>>,
-        counter: i64,
-    ) {
-        let (addr1, signer) = sdk_test::gen_secp256k1_signer(counter);
-        let msdk = MutationSDK::new(storage_client.clone(), signer, true);
-        let dm = sdk_test::create_a_database_mutation();
-        let result = msdk.submit_database_mutation(&dm).await;
-        assert!(result.is_ok(), "{:?}", result.err());
-        let sleep_seconds = time::Duration::from_millis(3000);
-        std::thread::sleep(sleep_seconds);
-        // add a collection
-        let (db_id, _) = result.unwrap();
-        println!("db id {}", db_id.to_hex());
-        let cm = sdk_test::create_a_collection_mutataion("collection1", db_id.address());
-        let result = msdk.submit_database_mutation(&cm).await;
-        assert!(result.is_ok());
-        std::thread::sleep(sleep_seconds);
-        let (addr, _signer) = sdk_test::gen_secp256k1_signer(counter);
-        let mut sdk = IndexerSDK::new(indexer_client.clone());
-        let my_dbs = sdk.get_my_database(addr1.to_hex().as_str()).await.unwrap();
-        assert_eq!(true, my_dbs.len() > 0);
-        let database = sdk.get_database(db_id.to_hex().as_str()).await;
-        if let Ok(Some(db)) = database {
-            assert_eq!(&db.address, db_id.address().as_ref());
-            assert_eq!(&db.sender, addr.as_ref());
-            assert_eq!(db.tx.len(), 2);
-            assert_eq!(db.collections.len(), 1);
-        } else {
-            assert!(false);
-        }
-        // add 4 documents
-        let docm = sdk_test::add_documents(
-            "collection1",
-            db_id.address(),
-            &vec![
-                r#"{"name": "John Doe","age": 43,"phones": ["+44 1234567","+44 2345678"]}"#,
-                r#"{"name": "Mike","age": 44,"phones": ["+44 1234567","+44 2345678"]}"#,
-                r#"{"name": "Bill","age": 44,"phones": ["+44 1234567","+44 2345678"]}"#,
-                r#"{"name": "Bill","age": 45,"phones": ["+44 1234567","+44 2345678"]}"#,
-            ],
-        );
-        let result = msdk.submit_database_mutation(&docm).await;
-        assert!(result.is_ok());
-        std::thread::sleep(sleep_seconds);
-
-        // show all documents
-        let documents = sdk
-            .list_documents(db_id.to_hex().as_str(), "collection1", None)
-            .await
-            .unwrap();
-        assert_eq!(documents.documents.len(), 4);
-
-        // list documents with limit=3
-        let documents = sdk
-            .list_documents(db_id.to_hex().as_str(), "collection1", Some(3))
-            .await
-            .unwrap();
-        assert_eq!(documents.documents.len(), 3);
-
-        // run query equivalent to SQL: select * from collection1 where name = "Bill"
-        let query = StructuredQuery {
-            collection_name: "collection1".to_string(),
-            select: Some(Projection { fields: vec![] }),
-            r#where: Some(Filter {
-                filter_type: Some(FilterType::FieldFilter(FieldFilter {
-                    field: "name".to_string(),
-                    op: Operator::Equal.into(),
-                    value: Some(Value {
-                        value_type: Some(ValueType::StringValue("Bill".to_string())),
-                    }),
-                })),
-            }),
-            limit: None,
-        };
-        println!("{}", serde_json::to_string(&query).unwrap());
-
-        let documents = sdk.run_query(db_id.to_hex().as_str(), query).await.unwrap();
-        assert_eq!(documents.documents.len(), 2);
-        std::thread::sleep(sleep_seconds);
-    }
-
-    fn create_storage_node_client() -> Arc<StorageNodeClient<tonic::transport::Channel>> {
-        let ep = "http://127.0.0.1:26659";
-        let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
-        let channel = rpc_endpoint.connect_lazy();
-        Arc::new(StorageNodeClient::new(channel))
-    }
-
-    fn create_indexer_node_client() -> Arc<IndexerNodeClient<tonic::transport::Channel>> {
-        let ep = "http://127.0.0.1:26639";
-        let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
-        let channel = rpc_endpoint.connect_lazy();
-        Arc::new(IndexerNodeClient::new(channel))
-    }
-
-    #[tokio::test]
-    async fn typed_data_doc_curd_happy_path_smoke_test() {
-        run_doc_crud_happy_path(
-            create_storage_node_client(),
-            create_indexer_node_client(),
-            131,
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    async fn indexer_status_test() {
-        let ep = "http://127.0.0.1:26639";
-        let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
-        let channel = rpc_endpoint.connect_lazy();
-        let client = Arc::new(IndexerNodeClient::new(channel));
-        let (_addr, _signer) = sdk_test::gen_ed25519_signer(150);
-        let sdk = IndexerSDK::new(client.clone());
-        let result = sdk.get_state().await;
-        assert!(result.is_ok());
-    }
-}
+//
+// pub struct IndexerSDK {
+//     client: Arc<IndexerNodeClient<tonic::transport::Channel>>,
+// }
+//
+// impl IndexerSDK {
+//     pub fn new(client: Arc<IndexerNodeClient<tonic::transport::Channel>>) -> Self {
+//         Self { client }
+//     }
+//
+//     /// show document with given db addr and collection name
+//     pub async fn list_documents(
+//         &mut self,
+//         addr: &str,
+//         collection_name: &str,
+//         limit: Option<i32>,
+//     ) -> std::result::Result<RunQueryResponse, Status> {
+//         self.run_query(
+//             addr,
+//             StructuredQuery {
+//                 collection_name: collection_name.to_string(),
+//                 limit: match limit {
+//                     Some(v) => Some(Limit { limit: v }),
+//                     None => None,
+//                 },
+//                 select: Some(Projection { fields: vec![] }),
+//                 r#where: None,
+//             },
+//         )
+//         .await
+//     }
+//
+//     /// get the document with a base64 format id
+//     pub async fn get_document(
+//         &mut self,
+//         id: &str,
+//     ) -> std::result::Result<Option<Document>, Status> {
+//         let r = GetDocumentRequest { id: id.to_string() };
+//
+//         let request = tonic::Request::new(r);
+//         let mut client = self.client.as_ref().clone();
+//         let response = client.get_document(request).await?.into_inner();
+//         Ok(response.document)
+//     }
+//
+//     ///
+//     /// get the information of database with a hex format address
+//     ///
+//     pub async fn get_database(
+//         &mut self,
+//         addr: &str,
+//     ) -> std::result::Result<Option<Database>, Status> {
+//         let r = ShowDatabaseRequest {
+//             address: addr.to_string(),
+//             owner_address: "".to_string(),
+//         };
+//         let request = tonic::Request::new(r);
+//         let mut client = self.client.as_ref().clone();
+//         let response = client.show_database(request).await?.into_inner();
+//         if response.dbs.len() > 0 {
+//             Ok(Some(response.dbs[0].clone()))
+//         } else {
+//             Ok(None)
+//         }
+//     }
+//
+//     ///
+//     /// get the information of database with a hex format address
+//     ///
+//     pub async fn get_my_database(
+//         &mut self,
+//         addr: &str,
+//     ) -> std::result::Result<Vec<Database>, Status> {
+//         let r = ShowDatabaseRequest {
+//             address: "".to_string(),
+//             owner_address: addr.to_string(),
+//         };
+//         let request = tonic::Request::new(r);
+//         let mut client = self.client.as_ref().clone();
+//         let response = client.show_database(request).await?.into_inner();
+//         Ok(response.dbs)
+//     }
+//
+//     /// query the document with structure query
+//     pub async fn run_query(
+//         &mut self,
+//         addr: &str,
+//         query: StructuredQuery,
+//     ) -> std::result::Result<RunQueryResponse, Status> {
+//         let r = RunQueryRequest {
+//             address: addr.to_string(),
+//             query: Some(query),
+//         };
+//         let request = tonic::Request::new(r);
+//         let mut client = self.client.as_ref().clone();
+//         let response = client.run_query(request).await?.into_inner();
+//         Ok(response)
+//     }
+//
+//     pub async fn get_state(&self) -> std::result::Result<IndexerStatus, Status> {
+//         let r = ShowIndexerStatusRequest {};
+//         let request = tonic::Request::new(r);
+//         let mut client = self.client.as_ref().clone();
+//         let status = client.show_indexer_status(request).await?.into_inner();
+//         Ok(status)
+//     }
+// }
+//
+// #[cfg(test)]
+// mod tests {
+//
+//     use super::*;
+//     use crate::mutation_sdk::MutationSDK;
+//     use crate::sdk_test;
+//
+//     use db3_proto::db3_database_proto::structured_query::field_filter::Operator;
+//     use db3_proto::db3_database_proto::structured_query::filter::FilterType;
+//     use db3_proto::db3_database_proto::structured_query::value::ValueType;
+//     use db3_proto::db3_database_proto::structured_query::{FieldFilter, Filter, Projection, Value};
+//     use db3_proto::db3_indexer_proto::indexer_node_client::IndexerNodeClient;
+//     use db3_proto::db3_node_proto::storage_node_client::StorageNodeClient;
+//     use std::sync::Arc;
+//     use std::time;
+//     use tonic::transport::Endpoint;
+//
+//     async fn run_doc_crud_happy_path(
+//         storage_client: Arc<StorageNodeClient<tonic::transport::Channel>>,
+//         indexer_client: Arc<IndexerNodeClient<tonic::transport::Channel>>,
+//         counter: i64,
+//     ) {
+//         let (addr1, signer) = sdk_test::gen_secp256k1_signer(counter);
+//         let msdk = MutationSDK::new(storage_client.clone(), signer, true);
+//         let dm = sdk_test::create_a_database_mutation();
+//         let result = msdk.submit_database_mutation(&dm).await;
+//         assert!(result.is_ok(), "{:?}", result.err());
+//         let sleep_seconds = time::Duration::from_millis(3000);
+//         std::thread::sleep(sleep_seconds);
+//         // add a collection
+//         let (db_id, _) = result.unwrap();
+//         println!("db id {}", db_id.to_hex());
+//         let cm = sdk_test::create_a_collection_mutataion("collection1", db_id.address());
+//         let result = msdk.submit_database_mutation(&cm).await;
+//         assert!(result.is_ok());
+//         std::thread::sleep(sleep_seconds);
+//         let (addr, _signer) = sdk_test::gen_secp256k1_signer(counter);
+//         let mut sdk = IndexerSDK::new(indexer_client.clone());
+//         let my_dbs = sdk.get_my_database(addr1.to_hex().as_str()).await.unwrap();
+//         assert_eq!(true, my_dbs.len() > 0);
+//         let database = sdk.get_database(db_id.to_hex().as_str()).await;
+//         if let Ok(Some(db)) = database {
+//             assert_eq!(&db.address, db_id.address().as_ref());
+//             assert_eq!(&db.sender, addr.as_ref());
+//             assert_eq!(db.tx.len(), 2);
+//             assert_eq!(db.collections.len(), 1);
+//         } else {
+//             assert!(false);
+//         }
+//         // add 4 documents
+//         let docm = sdk_test::add_documents(
+//             "collection1",
+//             db_id.address(),
+//             &vec![
+//                 r#"{"name": "John Doe","age": 43,"phones": ["+44 1234567","+44 2345678"]}"#,
+//                 r#"{"name": "Mike","age": 44,"phones": ["+44 1234567","+44 2345678"]}"#,
+//                 r#"{"name": "Bill","age": 44,"phones": ["+44 1234567","+44 2345678"]}"#,
+//                 r#"{"name": "Bill","age": 45,"phones": ["+44 1234567","+44 2345678"]}"#,
+//             ],
+//         );
+//         let result = msdk.submit_database_mutation(&docm).await;
+//         assert!(result.is_ok());
+//         std::thread::sleep(sleep_seconds);
+//
+//         // show all documents
+//         let documents = sdk
+//             .list_documents(db_id.to_hex().as_str(), "collection1", None)
+//             .await
+//             .unwrap();
+//         assert_eq!(documents.documents.len(), 4);
+//
+//         // list documents with limit=3
+//         let documents = sdk
+//             .list_documents(db_id.to_hex().as_str(), "collection1", Some(3))
+//             .await
+//             .unwrap();
+//         assert_eq!(documents.documents.len(), 3);
+//
+//         // run query equivalent to SQL: select * from collection1 where name = "Bill"
+//         let query = StructuredQuery {
+//             collection_name: "collection1".to_string(),
+//             select: Some(Projection { fields: vec![] }),
+//             r#where: Some(Filter {
+//                 filter_type: Some(FilterType::FieldFilter(FieldFilter {
+//                     field: "name".to_string(),
+//                     op: Operator::Equal.into(),
+//                     value: Some(Value {
+//                         value_type: Some(ValueType::StringValue("Bill".to_string())),
+//                     }),
+//                 })),
+//             }),
+//             limit: None,
+//         };
+//         println!("{}", serde_json::to_string(&query).unwrap());
+//
+//         let documents = sdk.run_query(db_id.to_hex().as_str(), query).await.unwrap();
+//         assert_eq!(documents.documents.len(), 2);
+//         std::thread::sleep(sleep_seconds);
+//     }
+//
+//     fn create_storage_node_client() -> Arc<StorageNodeClient<tonic::transport::Channel>> {
+//         let ep = "http://127.0.0.1:26659";
+//         let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
+//         let channel = rpc_endpoint.connect_lazy();
+//         Arc::new(StorageNodeClient::new(channel))
+//     }
+//
+//     fn create_indexer_node_client() -> Arc<IndexerNodeClient<tonic::transport::Channel>> {
+//         let ep = "http://127.0.0.1:26639";
+//         let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
+//         let channel = rpc_endpoint.connect_lazy();
+//         Arc::new(IndexerNodeClient::new(channel))
+//     }
+//
+//     #[tokio::test]
+//     async fn typed_data_doc_curd_happy_path_smoke_test() {
+//         run_doc_crud_happy_path(
+//             create_storage_node_client(),
+//             create_indexer_node_client(),
+//             131,
+//         )
+//         .await;
+//     }
+//
+//     #[tokio::test]
+//     async fn indexer_status_test() {
+//         let ep = "http://127.0.0.1:26639";
+//         let rpc_endpoint = Endpoint::new(ep.to_string()).unwrap();
+//         let channel = rpc_endpoint.connect_lazy();
+//         let client = Arc::new(IndexerNodeClient::new(channel));
+//         let (_addr, _signer) = sdk_test::gen_ed25519_signer(150);
+//         let sdk = IndexerSDK::new(client.clone());
+//         let result = sdk.get_state().await;
+//         assert!(result.is_ok());
+//     }
+// }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->
Resolve https://github.com/dbpunk-labs/db3/issues/486

### Change
- Indexer sync block from Store V2
- Apply mutationV2

### Todo

- Update/Delete mutation applay
- Query api
- Indexer State manage
- adapt db3.js with new indexer/store
- end2end test from db3.js
<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for a new version of `StoreSDK` and makes various changes to the codebase, including adding a new `DB3ClientContextV2` struct, updating function names, and adding logging statements.

### Detailed summary
- Adds `StoreSDKV2` and `DB3ClientContextV2`
- Renames `increase_block` to `increase_block_return_last_state`
- Adds logging statements in various functions
- Updates `DocStore` to return `Self` instead of `Result<Self>`
- Adds `add_str_docs` function to `DocStore`
- Updates `IndexerSDK` to remove unused functions and formatting

> The following files were skipped due to too many changes: `src/sdk/src/indexer_sdk.rs`, `src/node/src/indexer_impl.rs`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->