### PR TITLE
Feat/fix indexer doc store initialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ db3.log
 /bridge/artifacts/
 indexer.db
 indexer
+tools/mutation_db
+tools/doc_db
+tools/state_db

--- a/src/storage/src/db_store_v2.rs
+++ b/src/storage/src/db_store_v2.rs
@@ -83,7 +83,7 @@ impl DBStoreV2 {
 
         let doc_store = match config.enable_doc_store {
             false => Arc::new(DocStore::mock()),
-            true => Arc::new(DocStore::new(config.doc_store_conf.clone())),
+            true => Arc::new(DocStore::new(config.doc_store_conf.clone())?),
         };
 
         Ok(Self {

--- a/tools/start_localnet.sh
+++ b/tools/start_localnet.sh
@@ -49,9 +49,14 @@ then
 fi
 
 # clean indexer
-if [ -e ./indexer ]
+if [ -e ./indexer_doc_db ]
 then
-    rm -rf indexer
+    rm -rf indexer_doc_db
+fi
+
+if [ -e ./indexer_meta_db ]
+then
+    rm -rf indexer_meta_db
 fi
 
 echo "start ar miner..."


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

Fix the test failure in db3.js: [example](https://github.com/dbpunk-labs/db3.js/actions/runs/5280786477/jobs/9564105593)
```
   ● Console

    console.log
      RpcError: fail%20to%20read%20store%20for%20error%20collection%20with%20name%20col%20does%20not%20exist
          at /Users/chenjing/work/dbpunk/db3.js/node_modules/@protobuf-ts/grpcweb-transport/build/commonjs/grpc-web-transport.js:132:23
          at processTicksAndRejections (node:internal/process/task_queues:95:5) {
        code: 'INTERNAL',
        meta: {
          'access-control-allow-origin': '*',
          'content-length': '0',
          date: 'Fri, 16 Jun 2023 02:52:49 GMT',
          vary: 'origin, access-control-request-method, access-control-request-headers'
        },
        methodName: 'RunQuery',
        serviceName: 'db3_indexer_proto.IndexerNode'
      }

      at Object.log (tests/client_v2.test.ts:147:21)

  ● test db3.js client module › test query document
```

### Changes
- Init/Create dir for indexer_doc_db
- clean up indexer_doc_db and indexer_meta_db when start


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new databases and improves existing ones in the codebase, specifically adding mutation, document and state databases. It also improves error handling and logging.

### Detailed summary
- Added `tools/mutation_db`, `tools/doc_db`, and `tools/state_db`
- Improved error handling and logging
- Modified `src/storage/src/doc_store.rs`
  - Added file system module
  - Improved `new` function to return a `Result`
  - Improved `create_database` function to return a `Result`
- Modified `src/storage/src/db_store_v2.rs`
  - Improved `new` function to return a `Result`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->