### PR TITLE
clean doc id ownership entry when delete doc id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ indexer
 tools/mutation_db
 tools/doc_db
 tools/state_db
+bridge/artifacts
+bridge
+tools/index_doc_db
+tools/index_meta_db


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to delete documents from the owner store and verifies document ownership. It also makes a minor code change to the `delete_docs` function.

### Detailed summary
- Added `delete_doc_ids_from_owner_store` function to delete documents from the owner store
- Added `verify_docs_ownership` function to verify document ownership
- Modified `delete_docs` function to use the `?` operator

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->