### PR TITLE
add download arware and get last rollup tx in ar toolbox

### DIFF
--- a/src/error/src/lib.rs
+++ b/src/error/src/lib.rs
@@ -129,6 +129,8 @@ pub enum DB3Error {
     ReadStoreError(String),
     #[error("fail to rollup data for error {0}")]
     RollupError(String),
+    #[error("fail to implement arware op for error {0}")]
+    ArwareOpError(String),
     #[error("invalid collection name for error {0}")]
     InvalidCollectionNameError(String),
     #[error("invalid mutation for error {0}")]

--- a/src/node/src/rollup_executor.rs
+++ b/src/node/src/rollup_executor.rs
@@ -16,11 +16,8 @@
 //
 
 use crate::ar_toolbox::ArToolBox;
-use arrow::datatypes::*;
-use arrow::record_batch::RecordBatch;
 use db3_base::times;
 use db3_error::{DB3Error, Result};
-use db3_proto::db3_mutation_v2_proto::{MutationBody, MutationHeader};
 use db3_proto::db3_rollup_proto::{GcRecord, RollupRecord};
 use db3_storage::key_store::{KeyStore, KeyStoreConfig};
 use db3_storage::meta_store_client::MetaStoreClient;

--- a/src/storage/src/ar_fs.rs
+++ b/src/storage/src/ar_fs.rs
@@ -55,7 +55,7 @@ impl ArFileSystem {
             addr.as_str()
         );
         let arweave_url = url::Url::from_str(config.arweave_url.as_str())
-            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
 
         let wallet = WalletInfoClient::new(arweave_url);
         Ok(Self { arweave, wallet })
@@ -63,7 +63,7 @@ impl ArFileSystem {
 
     fn build_arweave(key_root_path: &str, url: &str) -> Result<Arweave> {
         let arweave_url =
-            url::Url::from_str(url).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            url::Url::from_str(url).map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         info!("recover ar key store from {}", key_root_path);
         let key_store_config = KeyStoreConfig {
             key_root_path: key_root_path.to_string(),
@@ -74,23 +74,23 @@ impl ArFileSystem {
                 let data = key_store.get_key("ar")?;
                 let data_ref: &[u8] = &data;
                 let priv_key: RsaPrivateKey = RsaPrivateKey::from_pkcs8_der(data_ref)
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
                 Arweave::from_private_key(priv_key, arweave_url)
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))
             }
             false => {
                 let mut rng = rand::thread_rng();
                 let bits = 2048;
                 let priv_key = RsaPrivateKey::new(&mut rng, bits)
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
                 let doc = priv_key
                     .to_pkcs8_der()
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
                 key_store
                     .write_key("ar", doc.as_ref())
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
                 Arweave::from_private_key(priv_key, arweave_url)
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))
             }
         }
     }
@@ -104,30 +104,30 @@ impl ArFileSystem {
             .wallet
             .balance(self.arweave.get_wallet_address().as_str())
             .await
-            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         let currency = Currency::from_str(balance.as_str())
-            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         Ok(currency)
     }
 
     pub async fn download_file(&self, path_to_write: &Path, tx: &str) -> Result<()> {
-        let tx_b64 = Base64::from_str(tx).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let tx_b64 = Base64::from_str(tx).map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         let (_status, data) = self
             .arweave
             .get_tx_data(&tx_b64)
             .await
-            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         if let Some(d) = data {
             let mut f =
-                File::create(path_to_write).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                File::create(path_to_write).map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             f.write_all(d.as_ref())
-                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
 
             f.sync_all()
-                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             Ok(())
         } else {
-            Err(DB3Error::RollupError("fail to download file".to_string()))
+            Err(DB3Error::ArwareOpError("fail to download file".to_string()))
         }
     }
 
@@ -142,18 +142,18 @@ impl ArFileSystem {
     ) -> Result<(String, u64)> {
         let mut tags: Vec<Tag<Base64>> = {
             let app_tag: Tag<Base64> = Tag::from_utf8_strs("App-Name", "DB3 Network")
-                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             let block_start_tag: Tag<Base64> =
                 Tag::from_utf8_strs("Start-Block", start_block.to_string().as_str())
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             let block_end_tag: Tag<Base64> =
                 Tag::from_utf8_strs("End-Block", end_block.to_string().as_str())
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             let filename_tag: Tag<Base64> = Tag::from_utf8_strs("File-Name", filename)
-                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             let network_tag: Tag<Base64> =
                 Tag::from_utf8_strs("Network-Id", network_id.to_string().as_str())
-                    .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                    .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             vec![
                 app_tag,
                 block_start_tag,
@@ -165,40 +165,75 @@ impl ArFileSystem {
 
         if !last_ar_tx.is_empty() {
             let value = Base64::from_utf8_str(last_ar_tx)
-                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             let name = Base64::from_utf8_str("Last-Rollup-Tx")
-                .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+                .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
             let last_rollup_tx = Tag::<Base64> { value, name };
             tags.push(last_rollup_tx);
         }
 
         let metadata =
-            std::fs::metadata(path).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            std::fs::metadata(path).map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         let fee = self
             .arweave
             .get_fee_by_size(metadata.len())
             .await
-            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         self.arweave
             .upload_file_from_path(path, tags, fee)
             .await
-            .map_err(|e| DB3Error::RollupError(format!("{e}")))
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))
     }
 
     pub async fn get_tx_status(&self, id: &str) -> Result<Option<TxStatus>> {
-        let tx_id = Base64::from_str(id).map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+        let tx_id = Base64::from_str(id).map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         let (code, status) = self
             .arweave
             .get_tx_status(&tx_id)
             .await
-            .map_err(|e| DB3Error::RollupError(format!("{e}")))?;
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
         if code == StatusCode::ACCEPTED {
             Ok(None)
         } else if code == StatusCode::OK {
             Ok(status)
         } else {
-            Err(DB3Error::RollupError("fail to get tx status ".to_string()))
+            Err(DB3Error::ArwareOpError(
+                "fail to get tx status ".to_string(),
+            ))
         }
+    }
+    pub async fn get_tags(&self, id_str: &str) -> Result<Vec<Tag<Base64>>> {
+        let tx_id =
+            Base64::from_str(id_str).map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
+        let (_status, tx) = self
+            .arweave
+            .get_tx(&tx_id)
+            .await
+            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
+
+        println!("tx {:?}", tx);
+        if let Some(t) = tx {
+            Ok(t.tags)
+        } else {
+            Err(DB3Error::ArwareOpError("fail to get tx tags ".to_string()))
+        }
+    }
+
+    /// get last rollup tag
+    pub async fn get_last_rollup_tag(&self, id_str: &str) -> Result<Option<String>> {
+        let tags = self.get_tags(id_str).await?;
+        for tag in tags {
+            if let Ok(name) = tag.name.to_utf8_string() {
+                if name == "Last-Rollup-Tx" {
+                    return Ok(Some(
+                        tag.value
+                            .to_utf8_string()
+                            .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?,
+                    ));
+                }
+            }
+        }
+        Ok(None)
     }
 }
 

--- a/src/storage/src/ar_fs.rs
+++ b/src/storage/src/ar_fs.rs
@@ -211,7 +211,6 @@ impl ArFileSystem {
             .await
             .map_err(|e| DB3Error::ArwareOpError(format!("{e}")))?;
 
-        println!("tx {:?}", tx);
         if let Some(t) = tx {
             Ok(t.tags)
         } else {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/imrtstore/rtstore-tpl/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/imrtstore/rtstore-tpl/blob/main/CHANGELOG.md
-->

### Change
- Add download arware file
- support API to get last rollup tx

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding new functionality and improving error handling for arware operations. 

### Detailed summary
- Added `ArwareOpError` error type.
- Added `ArwareOpError` variant to existing error handling code.
- Added new function `download_and_parse_record_batch` to download and parse record batches.
- Added new function `get_prev_arware_tx` to get the previous arware transaction.
- Updated existing functions to use `ArwareOpError` where necessary.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->