### PR TITLE
fix IndexType typo

### DIFF
--- a/sdk/src/store/database_v2.ts
+++ b/sdk/src/store/database_v2.ts
@@ -261,7 +261,7 @@ export async function showDatabase(owner: string, client: Client | ReadClient) {
  * ```ts
  * const index1:Index = {
  *    path:'/city', // a top level field name 'city' and the path will be '/city'
- *    indexType: Indextype.StringKey
+ *    indexType: IndexType.StringKey
  * }
  * const {collection, result} = await createCollection(db, "test_collection", [index1])
  * ```


### PR DESCRIPTION
I fixed a small typo on the documentation.

<!-- start pr-codex -->

---

## PR-Codex overview
### Focus of this PR:
Fixing a typo in the `database_v2.ts` file.

### Detailed summary:
- Fixed a typo in the `indexType` property from `Indextype` to `IndexType`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->